### PR TITLE
Merge results from engine adapter into current object

### DIFF
--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -47,13 +47,13 @@ module ActiveEncode
 
     def create!
       run_callbacks :create do
-        merge(self.class.engine_adapter.create(self))
+        merge!(self.class.engine_adapter.create(self))
       end
     end
 
     def cancel!
       run_callbacks :cancel do
-        merge(self.class.engine_adapter.cancel(self))
+        merge!(self.class.engine_adapter.cancel(self))
       end
     end
 
@@ -70,12 +70,12 @@ module ActiveEncode
     end
 
     def reload
-      merge(self.class.engine_adapter.find(id, cast: self.class))
+      merge!(self.class.engine_adapter.find(id, cast: self.class))
     end
 
     private
 
-      def merge(encode)
+      def merge!(encode)
         @id = encode.id
         @input = encode.input
         @output = encode.output
@@ -83,6 +83,12 @@ module ActiveEncode
         @current_operations = encode.current_operations
         @errors = encode.errors
         @tech_metadata = encode.tech_metadata
+        @created_at = encode.created_at
+        @finished_at = encode.finished_at
+        @updated_at = encode.updated_at
+        @options = encode.options
+        @percent_complete = encode.percent_complete
+
         self
       end
   end

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -47,13 +47,13 @@ module ActiveEncode
 
     def create!
       run_callbacks :create do
-        self.class.engine_adapter.create self
+        merge(self.class.engine_adapter.create(self))
       end
     end
 
     def cancel!
       run_callbacks :cancel do
-        self.class.engine_adapter.cancel self
+        merge(self.class.engine_adapter.cancel(self))
       end
     end
 
@@ -70,16 +70,20 @@ module ActiveEncode
     end
 
     def reload
-      fresh_encode = self.class.engine_adapter.find(id, cast: self.class)
-      @id = fresh_encode.id
-      @input = fresh_encode.input
-      @output = fresh_encode.output
-      @state = fresh_encode.state
-      @current_operations = fresh_encode.current_operations
-      @errors = fresh_encode.errors
-      @tech_metadata = fresh_encode.tech_metadata
-
-      self
+      merge(self.class.engine_adapter.find(id, cast: self.class))
     end
+
+    private
+
+      def merge(encode)
+        @id = encode.id
+        @input = encode.input
+        @output = encode.output
+        @state = encode.state
+        @current_operations = encode.current_operations
+        @errors = encode.errors
+        @tech_metadata = encode.tech_metadata
+        self
+      end
   end
 end

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -6,14 +6,15 @@ module ActiveEncode
       end
 
       def create(encode)
-        encode.id = SecureRandom.uuid
-        @encodes[encode.id] = encode
-        encode.state = :running
-        encode
+        new_encode = encode.dup
+        new_encode.id = SecureRandom.uuid
+        new_encode.state = :running
+        @encodes[new_encode.id] = new_encode
+        new_encode
       end
 
       def find(id, _opts = {})
-        @encodes[id]
+        @encodes[id].dup
       end
 
       def list(*_filters)
@@ -21,9 +22,10 @@ module ActiveEncode
       end
 
       def cancel(encode)
-        e = @encodes[encode.id]
-        e.state = :cancelled
-        e
+        new_encode = @encodes[encode.id].dup
+        new_encode.state = :cancelled
+        @encodes[encode.id] = new_encode
+        new_encode
       end
 
       def purge(encode)

--- a/spec/units/core_spec.rb
+++ b/spec/units/core_spec.rb
@@ -1,9 +1,116 @@
 require 'spec_helper'
 
 describe ActiveEncode::Core do
+  before do
+    class CustomEncode < ActiveEncode::Base
+    end
+  end
+   after do
+    Object.send(:remove_const, :CustomEncode)
+  end
+
+  let(:encode_class) { ActiveEncode::Base }
+
   describe 'find' do
-    it "raises NotFound when no id is supplied" do
-      expect { ActiveEncode::Base.find(nil) }.to raise_error(ArgumentError)
+    let(:id) { encode_class.create(nil).id }
+    subject { encode_class.find(id) }
+
+    it { is_expected.to be_a encode_class }
+    its(:id) { is_expected.to eq id }
+
+    context 'with no id' do
+      let(:id) { nil }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to be_a encode_class }
+      its(:id) { is_expected.to eq id }
+
+      context 'casting', :skip do
+        let(:id) { ActiveEncode::Base.create(nil).id }
+
+        it { is_expected.to be_a encode_class }
+        its(:id) { is_expected.to eq id }
+      end
+    end
+  end
+
+  describe 'create' do
+    subject { encode_class.create(nil) }
+
+    it { is_expected.to be_a encode_class }
+    its(:id) { is_expected.not_to be nil }
+    its(:state) { is_expected.not_to be nil }
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to be_a encode_class }
+      its(:id) { is_expected.not_to be nil }
+      its(:state) { is_expected.not_to be nil }
+    end
+  end
+
+  describe '#create!' do
+    let(:encode) { encode_class.new(nil) }
+    subject { encode.create! }
+
+    it { is_expected.to equal encode }
+    it { is_expected.to be_a encode_class }
+    its(:id) { is_expected.not_to be nil }
+    its(:state) { is_expected.not_to be nil }
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to equal encode }
+      it { is_expected.to be_a encode_class }
+      its(:id) { is_expected.not_to be nil }
+      its(:state) { is_expected.not_to be nil }
+    end
+  end
+
+  describe '#cancel!' do
+    let(:encode) { encode_class.create(nil) }
+    subject { encode.cancel! }
+
+    it { is_expected.to equal encode }
+    it { is_expected.to be_a encode_class }
+    its(:id) { is_expected.not_to be nil }
+    it { is_expected.to be_cancelled }
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to equal encode }
+      it { is_expected.to be_a encode_class }
+      its(:id) { is_expected.not_to be nil }
+      it { is_expected.to be_cancelled }
+    end
+  end
+
+  describe '#reload' do
+    let(:encode) { encode_class.create(nil) }
+    subject { encode.reload }
+
+    it { is_expected.to equal encode }
+    it { is_expected.to be_a encode_class }
+    its(:id) { is_expected.not_to be nil }
+    its(:state) { is_expected.not_to be nil }
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to equal encode }
+      it { is_expected.to be_a encode_class }
+      its(:id) { is_expected.not_to be nil }
+      its(:state) { is_expected.not_to be nil }
     end
   end
 end


### PR DESCRIPTION
Tests were added for core methods that were missing tests before.  I skipped the casting tests since they weren't working and might be reworked with globalid.