### PR TITLE
Persistence Mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ mkmf.log
 coverage
 .ruby-version
 .byebug_history
+
+.internal_test_app

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,38 @@ gem 'rubocop-rspec', require: false
 gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git"
 gem 'shingoncoder'
 gem 'zencoder'
+
+# BEGIN ENGINE_CART BLOCK
+# engine_cart: 2.0.1
+# engine_cart stanza: 0.10.0
+# the below comes from engine_cart, a gem used to test this Rails engine gem in the context of a Rails app.
+file = File.expand_path('Gemfile', ENV['ENGINE_CART_DESTINATION'] || ENV['RAILS_ROOT'] || File.expand_path('.internal_test_app', File.dirname(__FILE__)))
+if File.exist?(file)
+  begin
+    eval_gemfile file
+  rescue Bundler::GemfileError => e
+    Bundler.ui.warn '[EngineCart] Skipping Rails application dependencies:'
+    Bundler.ui.warn e.message
+  end
+else
+  Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
+
+  if ENV['RAILS_VERSION']
+    if ENV['RAILS_VERSION'] == 'edge'
+      gem 'rails', github: 'rails/rails'
+      ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+    else
+      gem 'rails', ENV['RAILS_VERSION']
+    end
+  end
+
+  case ENV['RAILS_VERSION']
+  when /^4.2/
+    gem 'responders', '~> 2.0'
+    gem 'sass-rails', '>= 5.0'
+    gem 'coffee-rails', '~> 4.1.0'
+  when /^4.[01]/
+    gem 'sass-rails', '< 5.0'
+  end
+end
+# END ENGINE_CART BLOCK

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 require 'rake/clean'
 require 'bundler'
 require 'rubocop/rake_task'
+require 'engine_cart/rake_task'
 
 Bundler::GemHelper.install_tasks
 
 desc "CI build"
-task ci: ["active_encode:adapters:clean", "active_encode:ci"]
+task ci: ["active_encode:ci"]
 desc "Rspec"
 task spec: ["active_encode:ci"]
 
@@ -23,16 +26,8 @@ namespace 'active_encode' do
   end
 
   desc "CI build"
-  task ci: [:rubocop, "active_encode:environment", "active_encode:adapters:start", "active_encode:spec"]
+  task ci: [:rubocop, "active_encode:environment", "engine_cart:generate", "active_encode:spec"]
 
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
-
-  namespace 'adapters' do
-    desc "Clean any local services needed by the adapters"
-    task 'clean' => []
-
-    desc "Start any local services needed by the adapters"
-    task 'start' => []
-  end
 end

--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -19,11 +19,14 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "rails"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-its", "~> 1.2"
+  spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "engine_cart"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "rspec-rails"
 end

--- a/app/models/active_encode/encode_record.rb
+++ b/app/models/active_encode/encode_record.rb
@@ -1,0 +1,5 @@
+module ActiveEncode
+  class EncodeRecord < ActiveRecord::Base
+    # sql id, globalid, state, adapter, input filename/job title, timestamps
+  end
+end

--- a/db/migrate/20180822021048_create_active_encode_encode_records.rb
+++ b/db/migrate/20180822021048_create_active_encode_encode_records.rb
@@ -1,0 +1,13 @@
+class CreateActiveEncodeEncodeRecords < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_encode_encode_records do |t|
+      t.string :global_id
+      t.string :state
+      t.string :adapter
+      t.string :title
+      t.text :raw_object
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/active_encode.rb
+++ b/lib/active_encode.rb
@@ -1,2 +1,3 @@
 require 'active_encode/version'
 require 'active_encode/base'
+require 'active_encode/engine'

--- a/lib/active_encode/base.rb
+++ b/lib/active_encode/base.rb
@@ -4,6 +4,7 @@ require 'active_encode/status'
 require 'active_encode/technical_metadata'
 require 'active_encode/callbacks'
 require 'active_encode/global_id'
+require 'active_encode/persistence'
 
 module ActiveEncode #:nodoc:
   class Base

--- a/lib/active_encode/callbacks.rb
+++ b/lib/active_encode/callbacks.rb
@@ -1,4 +1,4 @@
-require 'active_support/callbacks'
+require 'active_model/callbacks'
 
 module ActiveEncode
   # = Active Encode Callbacks
@@ -6,6 +6,8 @@ module ActiveEncode
   # Active Encode provides hooks during the life cycle of an encode. Callbacks allow you
   # to trigger logic during the life cycle of an encode. Available callbacks are:
   #
+  # * <tt>after_find</tt>
+  # * <tt>after_reload</tt>
   # * <tt>before_create</tt>
   # * <tt>around_create</tt>
   # * <tt>after_create</tt>
@@ -18,52 +20,30 @@ module ActiveEncode
   #
   module Callbacks
     extend ActiveSupport::Concern
-    include ActiveSupport::Callbacks
+
+    CALLBACKS = [
+      :after_find, :after_reload, :before_create, :around_create,
+      :after_create, :before_cancel, :around_cancel, :after_cancel,
+      :before_purge, :around_purge, :after_purge
+    ].freeze
 
     included do
-      define_callbacks :create
-      define_callbacks :cancel
-      define_callbacks :purge
-    end
+      extend ActiveModel::Callbacks
 
-    # These methods will be included into any Active Encode object, adding
-    # callbacks for +create+, +cancel+, and +purge+ methods.
-    module ClassMethods
-      def before_create(*filters, &blk)
-        set_callback(:create, :before, *filters, &blk)
-      end
+      define_model_callbacks :find, :reload, only: :after
+      define_model_callbacks :create, :cancel, :purge
 
-      def after_create(*filters, &blk)
-        set_callback(:create, :after, *filters, &blk)
-      end
-
-      def around_create(*filters, &blk)
-        set_callback(:create, :around, *filters, &blk)
-      end
-
-      def before_cancel(*filters, &blk)
-        set_callback(:cancel, :before, *filters, &blk)
-      end
-
-      def after_cancel(*filters, &blk)
-        set_callback(:cancel, :after, *filters, &blk)
-      end
-
-      def around_cancel(*filters, &blk)
-        set_callback(:cancel, :around, *filters, &blk)
-      end
-
-      def before_purge(*filters, &blk)
+      def self.before_purge(*filters, &blk)
         ActiveSupport::Deprecation.warn("before_purge will be removed without replacement in ActiveEncode 0.3")
         set_callback(:purge, :before, *filters, &blk)
       end
 
-      def after_purge(*filters, &blk)
+      def self.after_purge(*filters, &blk)
         ActiveSupport::Deprecation.warn("after_purge will be removed without replacement in ActiveEncode 0.3")
         set_callback(:purge, :after, *filters, &blk)
       end
 
-      def around_purge(*filters, &blk)
+      def self.around_purge(*filters, &blk)
         ActiveSupport::Deprecation.warn("around_purge will be removed without replacement in ActiveEncode 0.3")
         set_callback(:purge, :around, *filters, &blk)
       end

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -31,7 +31,8 @@ module ActiveEncode
 
       def find(id)
         raise ArgumentError, 'id cannot be nil' unless id
-        engine_adapter.find(id, cast: self)
+        encode = engine_adapter.find(id, cast: self)
+        encode.run_callbacks(:find) { encode }
       end
 
       def list(*args)
@@ -46,6 +47,7 @@ module ActiveEncode
     end
 
     def create!
+      # TODO: Raise ArgumentError if self has an id?
       run_callbacks :create do
         merge!(self.class.engine_adapter.create(self))
       end
@@ -70,7 +72,9 @@ module ActiveEncode
     end
 
     def reload
-      merge!(self.class.engine_adapter.find(id, cast: self.class))
+      run_callbacks :reload do
+        merge!(self.class.engine_adapter.find(id, cast: self.class))
+      end
     end
 
     private

--- a/lib/active_encode/engine.rb
+++ b/lib/active_encode/engine.rb
@@ -1,0 +1,7 @@
+require 'rails'
+
+module ActiveEncode
+  class Engine < ::Rails::Engine
+    isolate_namespace ActiveEncode
+  end
+end

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -9,12 +9,18 @@ module ActiveEncode
         new_encode = encode.dup
         new_encode.id = SecureRandom.uuid
         new_encode.state = :running
+        new_encode.created_at = Time.now
+        new_encode.updated_at = Time.now
         @encodes[new_encode.id] = new_encode
         new_encode
       end
 
       def find(id, _opts = {})
-        @encodes[id].dup
+        new_encode = @encodes[id].dup
+        # Update the updated_at time to simulate changes
+        new_encode.updated_at = Time.now
+        @encodes[id] = new_encode
+        new_encode
       end
 
       def list(*_filters)
@@ -24,6 +30,7 @@ module ActiveEncode
       def cancel(encode)
         new_encode = @encodes[encode.id].dup
         new_encode.state = :cancelled
+        new_encode.updated_at = Time.now
         @encodes[encode.id] = new_encode
         new_encode
       end

--- a/lib/active_encode/persistence.rb
+++ b/lib/active_encode/persistence.rb
@@ -1,0 +1,45 @@
+require 'active_support'
+
+module ActiveEncode
+  module Persistence
+    extend ActiveSupport::Concern
+
+    included do
+      after_find do |encode|
+        persist(persistence_model_attributes(encode))
+      end
+
+      after_create do |encode|
+        persist(persistence_model_attributes(encode))
+      end
+
+      after_cancel do |encode|
+        persist(persistence_model_attributes(encode))
+      end
+
+      after_reload do |encode|
+        persist(persistence_model_attributes(encode))
+      end
+    end
+
+    private
+
+      def persist(encode_attributes)
+        model = ActiveEncode::EncodeRecord.find_or_initialize_by(global_id: encode_attributes[:global_id])
+        model.update(encode_attributes) # Don't fail if persisting doesn't succeed?
+      end
+
+      def persistence_model_attributes(encode)
+        {
+          global_id: encode.to_global_id.to_s,
+          state: encode.state,
+          adapter: encode.class.engine_adapter.class.name,
+          title: encode.input.to_s,
+          # FIXME: Need to ensure that these values come through or else validations will fail
+          created_at: encode.created_at,
+          updated_at: encode.updated_at,
+          raw_object: encode.to_json
+        }
+      end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'engine_cart'
+EngineCart.load_application!
+
+require 'database_cleaner'
+
+RSpec.configure do |config|
+  config.before do |example|
+    if example.metadata[:db_clean]
+      DatabaseCleaner.clean_with(:truncation)
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
+  config.after do |example|
+    DatabaseCleaner.clean if example.metadata[:db_clean]
+  end
+end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -1,0 +1,15 @@
+        require 'rails/generators'
+
+        class TestAppGenerator < Rails::Generators::Base
+          source_root "./spec/test_app_templates"
+
+          # if you need to generate any additional configuration
+          # into the test app, this generator will be run immediately
+          # after setting up the application
+
+          def install_engine
+            generate 'active_encode:install'
+            rake 'active_encode:install:migrations'
+          end
+        end
+

--- a/spec/units/callbacks_spec.rb
+++ b/spec/units/callbacks_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe ActiveEncode::Callbacks do
   before do
     class CallbackEncode < ActiveEncode::Base
+      after_find ->(encode) { encode.history << "CallbackEncode ran after_find" }
+
+      after_reload ->(encode) { encode.history << "CallbackEncode ran after_reload" }
+
       before_create ->(encode) { encode.history << "CallbackEncode ran before_create" }
       after_create ->(encode) { encode.history << "CallbackEncode ran after_create" }
 
@@ -38,6 +42,18 @@ describe ActiveEncode::Callbacks do
 
   after do
     Object.send(:remove_const, :CallbackEncode)
+  end
+
+  describe 'find callback' do
+    let(:encode) { CallbackEncode.create("sample.mp4") }
+    subject { CallbackEncode.find(encode.id).history }
+    it { is_expected.to include("CallbackEncode ran after_find") }
+  end
+
+  describe 'reload callback' do
+    let(:encode) { CallbackEncode.create("sample.mp4") }
+    subject { encode.reload.history }
+    it { is_expected.to include("CallbackEncode ran after_reload") }
   end
 
   describe 'create callbacks' do

--- a/spec/units/persistence_spec.rb
+++ b/spec/units/persistence_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+describe ActiveEncode::Persistence, db_clean: true do
+  before do
+    class CustomEncode < ActiveEncode::Base
+      include ActiveEncode::Persistence
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :CustomEncode)
+  end
+
+  describe 'find' do
+    let(:encode) { CustomEncode.create(nil) }
+    subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+
+    it 'persists changes on find' do
+      expect { CustomEncode.find(encode.id) }.to change { subject.reload.updated_at }
+    end
+  end
+
+  describe 'create' do
+    let(:encode) { CustomEncode.create(nil) }
+    subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+
+    it 'creates a record' do
+      expect { encode }.to change { ActiveEncode::EncodeRecord.count }.by(1)
+    end
+
+    its(:global_id) { is_expected.to eq encode.to_global_id.to_s }
+    its(:state) { is_expected.to eq encode.state.to_s }
+    its(:adapter) { is_expected.to eq encode.class.engine_adapter.class.name }
+    its(:title) { is_expected.to eq encode.input.to_s }
+    its(:raw_object) { is_expected.to eq encode.to_json }
+    its(:created_at) { is_expected.to be_within(1.second).of encode.created_at }
+    its(:updated_at) { is_expected.to be_within(1.second).of encode.updated_at }
+  end
+
+  describe 'cancel' do
+    let(:encode) { CustomEncode.create(nil) }
+    subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+
+    it 'persists changes on cancel' do
+      expect { encode.cancel! }.to change { subject.reload.state }.from("running").to("cancelled")
+    end
+  end
+
+  describe 'reload' do
+    let(:encode) { CustomEncode.create(nil) }
+    subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+
+    it 'persists changes on reload' do
+      expect { encode.reload }.to change { subject.reload.updated_at }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an optional persistence mixin module that persists/caches a copy of the response from the adapter into an ActiveRecord database table.  At this point this cache isn't used for anything but future work could be retrieving from the database if the adapter no longer has the encode due to expiration.  This is also a building block for #15.

Since this PR, #14, and later #15 moves toward a Rails engine, this PR does that conversion.  This also makes testing easier by having a full Rails context for ActiveRecord testing.  If in the future we feel there are strong use cases for a non-Rails version of ActiveEncode then these pieces can be moved into a separate gem.

Fixes #13.