### PR TITLE
Tighten up the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ mkmf.log
 coverage
 .ruby-version
 .byebug_history
-
 .internal_test_app

--- a/lib/active_encode/base.rb
+++ b/lib/active_encode/base.rb
@@ -2,6 +2,8 @@ require 'active_encode/core'
 require 'active_encode/engine_adapter'
 require 'active_encode/status'
 require 'active_encode/technical_metadata'
+require 'active_encode/input'
+require 'active_encode/output'
 require 'active_encode/callbacks'
 require 'active_encode/global_id'
 require 'active_encode/persistence'
@@ -11,7 +13,6 @@ module ActiveEncode #:nodoc:
   class Base
     include Core
     include Status
-    include TechnicalMetadata
     include EngineAdapter
     include Callbacks
     include GlobalID

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -10,13 +10,21 @@ module ActiveEncode
       attr_accessor :id
 
       # Encode input
+      # @return ActiveEncode::Input
       attr_accessor :input
 
       # Encode output(s)
+      # @return Array[ActiveEncode::Output]
       attr_accessor :output
 
       # Encode options
       attr_accessor :options
+
+      attr_accessor :current_operations
+      attr_accessor :percent_complete
+
+      # @deprecated
+      attr_accessor :tech_metadata
     end
 
     module ClassMethods
@@ -74,6 +82,19 @@ module ActiveEncode
     def reload
       run_callbacks :reload do
         merge!(self.class.engine_adapter.find(id, cast: self.class))
+      end
+    end
+
+    def created?
+      !id.nil?
+    end
+
+    # @deprecated
+    def tech_metadata
+      metadata = {}
+      [:width, :height, :frame_rate, :duration, :file_size,
+       :audio_codec, :video_codec, :audio_bitrate, :video_bitrate, :checksum].each do |key|
+        metadata[key] = input.send(key)
       end
     end
 

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -32,7 +32,7 @@ module ActiveEncode
         {}
       end
 
-      def create(input_url, options = nil)
+      def create(input_url, options = {})
         object = new(input_url, options)
         object.create!
       end
@@ -59,8 +59,7 @@ module ActiveEncode
     def create!
       # TODO: Raise ArgumentError if self has an id?
       run_callbacks :create do
-        # merge!(self.class.engine_adapter.create(self.input.url, self.options))
-        merge!(self.class.engine_adapter.create(self))
+        merge!(self.class.engine_adapter.create(self.input.url, self.options))
       end
     end
 

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -66,7 +66,7 @@ module ActiveEncode
 
     def cancel!
       run_callbacks :cancel do
-        merge!(self.class.engine_adapter.cancel(self))
+        merge!(self.class.engine_adapter.cancel(self.id))
       end
     end
 

--- a/lib/active_encode/engine_adapters/active_job_adapter.rb
+++ b/lib/active_encode/engine_adapters/active_job_adapter.rb
@@ -5,13 +5,13 @@ module ActiveEncode
         ActiveSupport::Deprecation.warn("The ActiveJobAdapter is deprecated and will be removed in ActiveEncode 0.3.")
       end
 
-      def create(_encode) end
+      def create(_input_url, _options) end
 
-      def find(_id, _opts = {}) end
+      def find(_id) end
 
       def list(*_filters) end
 
-      def cancel(_encode) end
+      def cancel(_id end
 
       def purge(_encode) end
 

--- a/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
@@ -2,13 +2,13 @@ module ActiveEncode
   module EngineAdapters
     class ElasticTranscoderAdapter
       # TODO: add a stub for an input helper (supplied by an initializer) that transforms encode.input into a zencoder accepted url
-      def create(encode)
+      def create(input_url, options = {})
         job = client.create_job(
-          input: { key: encode.input.url },
-          pipeline_id: encode.options[:pipeline_id],
-          output_key_prefix: encode.options[:output_key_prefix],
-          outputs: encode.options[:outputs],
-          user_metadata: encode.options[:user_metadata]
+          input: { key: input_url },
+          pipeline_id: options[:pipeline_id],
+          output_key_prefix: options[:output_key_prefix],
+          outputs: options[:outputs],
+          user_metadata: options[:user_metadata]
         ).job
 
         build_encode(job)

--- a/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
@@ -24,9 +24,9 @@ module ActiveEncode
       end
 
       # Can only cancel jobs with status = "Submitted"
-      def cancel(encode)
-        response = client.cancel_job(id: encode.id)
-        build_encode(get_job_details(encode.id)) if response.successful?
+      def cancel(id)
+        response = client.cancel_job(id: id)
+        build_encode(get_job_details(id)) if response.successful?
       end
 
       def purge(_encode)

--- a/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
@@ -4,18 +4,18 @@ module ActiveEncode
       # TODO: add a stub for an input helper (supplied by an initializer) that transforms encode.input into a zencoder accepted url
       def create(encode)
         job = client.create_job(
-          input: { key: encode.input },
+          input: { key: encode.input.url },
           pipeline_id: encode.options[:pipeline_id],
           output_key_prefix: encode.options[:output_key_prefix],
           outputs: encode.options[:outputs],
           user_metadata: encode.options[:user_metadata]
         ).job
 
-        build_encode(job, encode.class)
+        build_encode(job)
       end
 
       def find(id, opts = {})
-        build_encode(get_job_details(id), opts[:cast])
+        build_encode(get_job_details(id))
       end
 
       # TODO: implement list_jobs_by_pipeline and list_jobs_by_status
@@ -26,7 +26,7 @@ module ActiveEncode
       # Can only cancel jobs with status = "Submitted"
       def cancel(encode)
         response = client.cancel_job(id: encode.id)
-        build_encode(get_job_details(encode.id), encode.class) if response.successful?
+        build_encode(get_job_details(encode.id)) if response.successful?
       end
 
       def purge(_encode)
@@ -48,9 +48,9 @@ module ActiveEncode
           client.read_job(id: job_id).job
         end
 
-        def build_encode(job, cast)
+        def build_encode(job)
           return nil if job.nil?
-          encode = cast.new(convert_input(job), convert_options(job))
+          encode = ActiveEncode::Base.new(convert_input(job), convert_options(job))
           encode.id = job.id
           encode.state = convert_state(job)
           encode.current_operations = convert_current_operations(job)

--- a/lib/active_encode/engine_adapters/inline_adapter.rb
+++ b/lib/active_encode/engine_adapters/inline_adapter.rb
@@ -8,7 +8,8 @@ module ActiveEncode
         ActiveSupport::Deprecation.warn("The InlineAdapter is deprecated and will be removed in ActiveEncode 0.3.")
       end
 
-      def create(encode)
+      def create(input_url, options = {})
+        encode = ActiveEncode::Base.new(input_url, options)
         encode.id = SecureRandom.uuid
         self.class.encodes[encode.id] = encode
         # start encode

--- a/lib/active_encode/engine_adapters/matterhorn_adapter.rb
+++ b/lib/active_encode/engine_adapters/matterhorn_adapter.rb
@@ -23,8 +23,8 @@ module ActiveEncode
         raise NotImplementedError # TODO: implement this
       end
 
-      def cancel(encode)
-        workflow_om = Rubyhorn.client.stop(encode.id)
+      def cancel(id)
+        workflow_om = Rubyhorn.client.stop(id)
         build_encode(get_workflow(workflow_om))
       end
 

--- a/lib/active_encode/engine_adapters/matterhorn_adapter.rb
+++ b/lib/active_encode/engine_adapters/matterhorn_adapter.rb
@@ -7,16 +7,16 @@ module ActiveEncode
 
       def create(encode)
         workflow_id = encode.options[:preset] || "full"
-        workflow_om = if encode.input.is_a? Hash
-                        create_multiple_files(encode.input, workflow_id)
-                      else
-                        Rubyhorn.client.addMediaPackageWithUrl(DEFAULT_ARGS.merge('workflow' => workflow_id, 'url' => encode.input, 'filename' => File.basename(encode.input), 'title' => File.basename(encode.input)))
-                      end
-        build_encode(get_workflow(workflow_om), encode.class)
+        # workflow_om = if encode.input.is_a? Hash
+        #                 create_multiple_files(encode.input, workflow_id)
+        #               else
+                        workflow_om = Rubyhorn.client.addMediaPackageWithUrl(DEFAULT_ARGS.merge('workflow' => workflow_id, 'url' => encode.input.url, 'filename' => File.basename(encode.input.url), 'title' => File.basename(encode.input.url)))
+                      # end
+        build_encode(get_workflow(workflow_om))
       end
 
       def find(id, opts = {})
-        build_encode(fetch_workflow(id), opts[:cast])
+        build_encode(fetch_workflow(id))
       end
 
       def list(*_filters)
@@ -25,7 +25,7 @@ module ActiveEncode
 
       def cancel(encode)
         workflow_om = Rubyhorn.client.stop(encode.id)
-        build_encode(get_workflow(workflow_om), encode.class)
+        build_encode(get_workflow(workflow_om))
       end
 
       def purge(encode)
@@ -41,7 +41,7 @@ module ActiveEncode
                         end
         purged_workflow = purge_outputs(get_workflow(workflow_om))
         # Rubyhorn.client.delete_instance(encode.id) #Delete is not working so workflow instances can always be retrieved later!
-        build_encode(purged_workflow, encode.class)
+        build_encode(purged_workflow)
       end
 
       def remove_output(encode, output_id)
@@ -79,9 +79,9 @@ module ActiveEncode
           end
         end
 
-        def build_encode(workflow, cast)
+        def build_encode(workflow)
           return nil if workflow.nil?
-          encode = cast.new(convert_input(workflow), convert_options(workflow))
+          encode = ActiveEncode::Base.new(convert_input(workflow), convert_options(workflow))
           encode.id = convert_id(workflow)
           encode.state = convert_state(workflow)
           encode.current_operations = convert_current_operations(workflow)

--- a/lib/active_encode/engine_adapters/matterhorn_adapter.rb
+++ b/lib/active_encode/engine_adapters/matterhorn_adapter.rb
@@ -5,12 +5,12 @@ module ActiveEncode
     class MatterhornAdapter
       DEFAULT_ARGS = { 'flavor' => 'presenter/source' }.freeze
 
-      def create(encode)
-        workflow_id = encode.options[:preset] || "full"
+      def create(input_url, options = {})
+        workflow_id = options[:preset] || "full"
         # workflow_om = if encode.input.is_a? Hash
         #                 create_multiple_files(encode.input, workflow_id)
         #               else
-                        workflow_om = Rubyhorn.client.addMediaPackageWithUrl(DEFAULT_ARGS.merge('workflow' => workflow_id, 'url' => encode.input.url, 'filename' => File.basename(encode.input.url), 'title' => File.basename(encode.input.url)))
+                        workflow_om = Rubyhorn.client.addMediaPackageWithUrl(DEFAULT_ARGS.merge('workflow' => workflow_id, 'url' => input_url, 'filename' => File.basename(input_url), 'title' => File.basename(input_url)))
                       # end
         build_encode(get_workflow(workflow_om))
       end

--- a/lib/active_encode/engine_adapters/shingoncoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/shingoncoder_adapter.rb
@@ -9,8 +9,8 @@ module ActiveEncode
       end
 
       # @param [ActiveEncode::Base] encode
-      def create(encode)
-        response = Shingoncoder::Job.create(input: encode.input.url)
+      def create(input_url, options = {})
+        response = Shingoncoder::Job.create(input: input_url)
         build_encode(job_details(response.body["id"]))
       end
 

--- a/lib/active_encode/engine_adapters/shingoncoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/shingoncoder_adapter.rb
@@ -10,21 +10,21 @@ module ActiveEncode
 
       # @param [ActiveEncode::Base] encode
       def create(encode)
-        response = Shingoncoder::Job.create(input: encode.input)
-        build_encode(job_details(response.body["id"]), encode.class)
+        response = Shingoncoder::Job.create(input: encode.input.url)
+        build_encode(job_details(response.body["id"]))
       end
 
       # @param [Fixnum] id
       # @param [Hash] opts
       # @option opts :cast the class to cast the encoding job to.
       def find(id, opts = {})
-        build_encode(job_details(id), opts[:cast])
+        build_encode(job_details(id))
       end
 
       # @param [ActiveEncode::Base] encode
       def cancel(encode)
         response = Shingoncoder::Job.cancel(encode.id)
-        build_encode(job_details(encode.id), encode.class) if response.success?
+        build_encode(job_details(encode.id)) if response.success?
       end
 
       private
@@ -42,9 +42,9 @@ module ActiveEncode
 
         # @param [Shingoncoder::Response] job_details
         # @param [Class] cast the class of object to instantiate and return
-        def build_encode(job_details, cast)
+        def build_encode(job_details)
           return nil if job_details.nil?
-          encode = cast.new(convert_input(job_details), convert_options(job_details))
+          encode = ActiveEncode::Base.new(convert_input(job_details), convert_options(job_details))
           encode.id = job_details.body["job"]["id"].to_s
           encode.state = convert_state(job_details)
           progress = job_progress(encode.id)

--- a/lib/active_encode/engine_adapters/shingoncoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/shingoncoder_adapter.rb
@@ -22,9 +22,9 @@ module ActiveEncode
       end
 
       # @param [ActiveEncode::Base] encode
-      def cancel(encode)
-        response = Shingoncoder::Job.cancel(encode.id)
-        build_encode(job_details(encode.id)) if response.success?
+      def cancel(id)
+        response = Shingoncoder::Job.cancel(id)
+        build_encode(job_details(id)) if response.success?
       end
 
       private

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -23,11 +23,11 @@ module ActiveEncode
         new_encode
       end
 
-      def cancel(encode)
-        new_encode = @encodes[encode.id].dup
+      def cancel(id)
+        new_encode = @encodes[id].dup
         new_encode.state = :cancelled
         new_encode.updated_at = Time.now
-        @encodes[encode.id] = new_encode
+        @encodes[id] = new_encode
         new_encode
       end
 

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -16,18 +16,16 @@ module ActiveEncode
       end
 
       def find(id, _opts = {})
-        new_encode = @encodes[id].dup
+        new_encode = @encodes[id]
         # Update the updated_at time to simulate changes
         new_encode.updated_at = Time.now
-        @encodes[id] = new_encode
         new_encode
       end
 
       def cancel(id)
-        new_encode = @encodes[id].dup
+        new_encode = @encodes[id]
         new_encode.state = :cancelled
         new_encode.updated_at = Time.now
-        @encodes[id] = new_encode
         new_encode
       end
 

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -5,8 +5,8 @@ module ActiveEncode
         @encodes = {}
       end
 
-      def create(encode)
-        new_encode = ActiveEncode::Base.new(nil).send(:merge!, encode.dup)
+      def create(input_url, options = {})
+        new_encode = ActiveEncode::Base.new(input_url, options)
         new_encode.id = SecureRandom.uuid
         new_encode.state = :running
         new_encode.created_at = Time.now

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -23,16 +23,16 @@ module ActiveEncode
         new_encode
       end
 
-      def list(*_filters)
-        raise NotImplementedError
-      end
-
       def cancel(encode)
         new_encode = @encodes[encode.id].dup
         new_encode.state = :cancelled
         new_encode.updated_at = Time.now
         @encodes[encode.id] = new_encode
         new_encode
+      end
+
+      def list(*_filters)
+        raise NotImplementedError
       end
 
       def purge(encode)

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -6,7 +6,7 @@ module ActiveEncode
       end
 
       def create(encode)
-        new_encode = encode.dup
+        new_encode = ActiveEncode::Base.new(nil).send(:merge!, encode.dup)
         new_encode.id = SecureRandom.uuid
         new_encode.state = :running
         new_encode.created_at = Time.now

--- a/lib/active_encode/engine_adapters/zencoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/zencoder_adapter.rb
@@ -2,8 +2,8 @@ module ActiveEncode
   module EngineAdapters
     class ZencoderAdapter
       # TODO: add a stub for an input helper (supplied by an initializer) that transforms encode.input.url into a zencoder accepted url
-      def create(encode)
-        response = Zencoder::Job.create(input: encode.input.url.to_s)
+      def create(input_url, options = {})
+        response = Zencoder::Job.create(input: input_url.to_s)
         build_encode(get_job_details(response.body["id"]))
       end
 

--- a/lib/active_encode/engine_adapters/zencoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/zencoder_adapter.rb
@@ -15,9 +15,9 @@ module ActiveEncode
         raise NotImplementedError
       end
 
-      def cancel(encode)
-        response = Zencoder::Job.cancel(encode.id)
-        build_encode(get_job_details(encode.id)) if response.success?
+      def cancel(id)
+        response = Zencoder::Job.cancel(id)
+        build_encode(get_job_details(id)) if response.success?
       end
 
       def purge(_encode)

--- a/lib/active_encode/engine_adapters/zencoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/zencoder_adapter.rb
@@ -1,14 +1,14 @@
 module ActiveEncode
   module EngineAdapters
     class ZencoderAdapter
-      # TODO: add a stub for an input helper (supplied by an initializer) that transforms encode.input into a zencoder accepted url
+      # TODO: add a stub for an input helper (supplied by an initializer) that transforms encode.input.url into a zencoder accepted url
       def create(encode)
-        response = Zencoder::Job.create(input: encode.input.to_s)
-        build_encode(get_job_details(response.body["id"]), encode.class)
+        response = Zencoder::Job.create(input: encode.input.url.to_s)
+        build_encode(get_job_details(response.body["id"]))
       end
 
       def find(id, opts = {})
-        build_encode(get_job_details(id), opts[:cast])
+        build_encode(get_job_details(id))
       end
 
       def list(*_filters)
@@ -17,7 +17,7 @@ module ActiveEncode
 
       def cancel(encode)
         response = Zencoder::Job.cancel(encode.id)
-        build_encode(get_job_details(encode.id), encode.class) if response.success?
+        build_encode(get_job_details(encode.id)) if response.success?
       end
 
       def purge(_encode)
@@ -38,9 +38,9 @@ module ActiveEncode
           Zencoder::Job.progress(job_id)
         end
 
-        def build_encode(job_details, cast)
+        def build_encode(job_details)
           return nil if job_details.nil?
-          encode = cast.new(convert_input(job_details), convert_options(job_details))
+          encode = ActiveEncode::Base.new(convert_input(job_details), convert_options(job_details))
           encode.id = job_details.body["job"]["id"].to_s
           encode.state = convert_state(job_details)
           job_progress = get_job_progress(encode.id)

--- a/lib/active_encode/input.rb
+++ b/lib/active_encode/input.rb
@@ -1,0 +1,9 @@
+module ActiveEncode
+  class Input
+    include Status
+    include TechnicalMetadata
+
+    attr_accessor :id
+    attr_accessor :url
+  end
+end

--- a/lib/active_encode/output.rb
+++ b/lib/active_encode/output.rb
@@ -1,0 +1,9 @@
+module ActiveEncode
+  class Output
+    include Status
+    include TechnicalMetadata
+
+    attr_accessor :id
+    attr_accessor :url
+  end
+end

--- a/lib/active_encode/persistence.rb
+++ b/lib/active_encode/persistence.rb
@@ -34,7 +34,7 @@ module ActiveEncode
           global_id: encode.to_global_id.to_s,
           state: encode.state,
           adapter: encode.class.engine_adapter.class.name,
-          title: encode.input.to_s,
+          title: encode.input.url.to_s,
           # FIXME: Need to ensure that these values come through or else validations will fail
           created_at: encode.created_at,
           updated_at: encode.updated_at,

--- a/lib/active_encode/status.rb
+++ b/lib/active_encode/status.rb
@@ -7,17 +7,13 @@ module ActiveEncode
     included do
       # Current state of the encoding process
       attr_accessor :state
-      attr_accessor :current_operations
-      attr_accessor :percent_complete
       attr_accessor :errors
 
       attr_accessor :created_at
-      attr_accessor :finished_at
       attr_accessor :updated_at
-    end
 
-    def created?
-      !id.nil?
+      # @deprecated
+      attr_accessor :finished_at
     end
 
     def cancelled?

--- a/lib/active_encode/technical_metadata.rb
+++ b/lib/active_encode/technical_metadata.rb
@@ -5,7 +5,22 @@ module ActiveEncode
     extend ActiveSupport::Concern
 
     included do
-      attr_accessor :tech_metadata
+      attr_accessor :width
+      attr_accessor :height
+      attr_accessor :frame_rate
+
+      # In milliseconds
+      attr_accessor :duration
+
+      # In bytes
+      attr_accessor :file_size
+
+      attr_accessor :checksum
+
+      attr_accessor :audio_codec
+      attr_accessor :video_codec
+      attr_accessor :audio_bitrate
+      attr_accessor :video_bitrate
     end
   end
 end

--- a/spec/shared_specs/engine_adapter_specs.rb
+++ b/spec/shared_specs/engine_adapter_specs.rb
@@ -31,7 +31,9 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
     context "a running encode" do
       subject { running_job }
 
-      it { is_expected.to be_a ActiveEncode::Base }
+      it 'returns an ActiveEncode::Base object' do
+        expect(subject.class).to be ActiveEncode::Base
+      end
       its(:id) { is_expected.to eq 'running-id' }
       it { is_expected.to be_running }
       its(:percent_complete) { is_expected.to be > 0 }
@@ -44,7 +46,9 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
     context "a cancelled encode" do
       subject { canceled_job }
 
-      it { is_expected.to be_a ActiveEncode::Base }
+      it 'returns an ActiveEncode::Base object' do
+        expect(subject.class).to be ActiveEncode::Base
+      end
       its(:id) { is_expected.to eq 'cancelled-id' }
       it { is_expected.to be_cancelled }
       its(:percent_complete) { is_expected.to be > 0 }
@@ -57,7 +61,9 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
     context "a completed encode" do
       subject { completed_job }
 
-      it { is_expected.to be_a ActiveEncode::Base }
+      it 'returns an ActiveEncode::Base object' do
+        expect(subject.class).to be ActiveEncode::Base
+      end
       its(:id) { is_expected.to eq 'completed-id' }
       it { is_expected.to be_completed }
       its(:output) { is_expected.to eq completed_output }
@@ -72,7 +78,9 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
     context "a failed encode" do
       subject { failed_job }
 
-      it { is_expected.to be_a ActiveEncode::Base }
+      it 'returns an ActiveEncode::Base object' do
+        expect(subject.class).to be ActiveEncode::Base
+      end
       its(:id) { is_expected.to eq 'failed-id' }
       it { is_expected.to be_failed }
       its(:percent_complete) { is_expected.to be > 0 }
@@ -87,7 +95,9 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
   describe "#cancel!" do
     subject { cancelling_job.cancel! }
 
-    it { is_expected.to be_a ActiveEncode::Base }
+    it 'returns an ActiveEncode::Base object' do
+      expect(subject.class).to be ActiveEncode::Base
+    end
     its(:id) { is_expected.to eq 'cancelled-id' }
     it { is_expected.to be_cancelled }
     its(:percent_complete) { is_expected.to be > 0 }
@@ -100,7 +110,9 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
   describe "reload" do
     subject { running_job.reload }
 
-    it { is_expected.to be_a ActiveEncode::Base }
+    it 'returns an ActiveEncode::Base object' do
+      expect(subject.class).to be ActiveEncode::Base
+    end
     its(:id) { is_expected.to eq 'running-id' }
     it { is_expected.to be_running }
     its(:percent_complete) { is_expected.to be > 0 }

--- a/spec/units/callbacks_spec.rb
+++ b/spec/units/callbacks_spec.rb
@@ -13,9 +13,6 @@ describe ActiveEncode::Callbacks do
       before_cancel ->(encode) { encode.history << "CallbackEncode ran before_cancel" }
       after_cancel ->(encode) { encode.history << "CallbackEncode ran after_cancel" }
 
-      before_purge ->(encode) { encode.history << "CallbackEncode ran before_purge" }
-      after_purge ->(encode) { encode.history << "CallbackEncode ran after_purge" }
-
       around_create do |encode, block|
         encode.history << "CallbackEncode ran around_create_start"
         block.call
@@ -26,12 +23,6 @@ describe ActiveEncode::Callbacks do
         encode.history << "CallbackEncode ran around_cancel_start"
         block.call
         encode.history << "CallbackEncode ran around_cancel_stop"
-      end
-
-      around_purge do |encode, block|
-        encode.history << "CallbackEncode ran around_purge_start"
-        block.call
-        encode.history << "CallbackEncode ran around_purge_stop"
       end
 
       def history
@@ -70,13 +61,5 @@ describe ActiveEncode::Callbacks do
     it { is_expected.to include("CallbackEncode ran after_cancel") }
     it { is_expected.to include("CallbackEncode ran around_cancel_start") }
     it { is_expected.to include("CallbackEncode ran around_cancel_stop") }
-  end
-
-  describe 'purge callbacks' do
-    subject { CallbackEncode.create("sample.mp4").purge!.history }
-    it { is_expected.to include("CallbackEncode ran before_purge") }
-    it { is_expected.to include("CallbackEncode ran after_purge") }
-    it { is_expected.to include("CallbackEncode ran around_purge_start") }
-    it { is_expected.to include("CallbackEncode ran around_purge_stop") }
   end
 end

--- a/spec/units/core_spec.rb
+++ b/spec/units/core_spec.rb
@@ -44,7 +44,7 @@ describe ActiveEncode::Core do
       it { is_expected.to be_a encode_class }
       its(:id) { is_expected.to eq id }
 
-      context 'casting', :skip do
+      context 'casting' do
         let(:id) { ActiveEncode::Base.create(nil).id }
 
         it { is_expected.to be_a encode_class }

--- a/spec/units/core_spec.rb
+++ b/spec/units/core_spec.rb
@@ -11,6 +11,18 @@ describe ActiveEncode::Core do
 
   let(:encode_class) { ActiveEncode::Base }
 
+  describe 'attributes' do
+    subject { encode_class.new(nil) }
+
+    it { is_expected.to respond_to(:id, :input, :output, :options, :percent_complete, :current_operations) }
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to respond_to(:id, :input, :output, :options, :percent_complete, :current_operations) }
+    end
+  end
+
   describe 'find' do
     let(:id) { encode_class.create(nil).id }
     subject { encode_class.find(id) }

--- a/spec/units/input_spec.rb
+++ b/spec/units/input_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe ActiveEncode::Input do
+  subject { described_class.new }
+
+  describe 'attributes' do
+    it { is_expected.to respond_to(:id, :url) }
+    it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }
+    it { is_expected.to respond_to(:width, :height, :frame_rate, :checksum,
+                                   :audio_codec, :video_codec, :audio_bitrate, :video_bitrate) }
+  end
+end

--- a/spec/units/output_spec.rb
+++ b/spec/units/output_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe ActiveEncode::Output do
+  subject { described_class.new }
+
+  describe 'attributes' do
+    it { is_expected.to respond_to(:id, :url) }
+    it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }
+    it { is_expected.to respond_to(:width, :height, :frame_rate, :checksum,
+                                   :audio_codec, :video_codec, :audio_bitrate, :video_bitrate) }
+  end
+end

--- a/spec/units/persistence_spec.rb
+++ b/spec/units/persistence_spec.rb
@@ -31,7 +31,7 @@ describe ActiveEncode::Persistence, db_clean: true do
     its(:global_id) { is_expected.to eq encode.to_global_id.to_s }
     its(:state) { is_expected.to eq encode.state.to_s }
     its(:adapter) { is_expected.to eq encode.class.engine_adapter.class.name }
-    its(:title) { is_expected.to eq encode.input.to_s }
+    its(:title) { is_expected.to eq encode.input.url.to_s }
     its(:raw_object) { is_expected.to eq encode.to_json }
     its(:created_at) { is_expected.to be_within(1.second).of encode.created_at }
     its(:updated_at) { is_expected.to be_within(1.second).of encode.updated_at }

--- a/spec/units/status_spec.rb
+++ b/spec/units/status_spec.rb
@@ -1,10 +1,29 @@
 require 'spec_helper'
 
 describe ActiveEncode::Status do
-  subject { ActiveEncode::Base.new(nil) }
+  before do
+    class CustomEncode < ActiveEncode::Base
+    end
+  end
+   after do
+    Object.send(:remove_const, :CustomEncode)
+  end
+
+  let(:encode_class) { ActiveEncode::Base }
+
+  subject { encode_class.new(nil) }
+
+  describe 'attributes' do
+    it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }
+
+    context 'with an ActiveEncode::Base subclass' do
+      let(:encode_class) { CustomEncode }
+
+      it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }
+    end
+  end
 
   context 'new object' do
-    subject { ActiveEncode::Base.new(nil) }
     it { is_expected.not_to be_created }
     it { is_expected.not_to be_running }
     it { is_expected.not_to be_cancelled }


### PR DESCRIPTION
EngineAdapter's api is now:
#create(input_url, options)
#find(id)
#cancel(id)

The properties available in TechnicalMetadata are now enumerated and input and output are now objects instead of hashes.

After this PR is merged we should probably cut 0.2.

Fixes #31 .