### PR TITLE
Fix polling callbacks

### DIFF
--- a/app/jobs/active_encode/polling_job.rb
+++ b/app/jobs/active_encode/polling_job.rb
@@ -4,12 +4,12 @@ module ActiveEncode
     def perform(encode)
       encode.run_callbacks(:status_update) { encode }
       case encode.state
-      when :error
-        encode.run_callbacks(:error) { encode }
+      when :failed
+        encode.run_callbacks(:failed) { encode }
       when :cancelled
         encode.run_callbacks(:cancelled) { encode }
-      when :complete
-        encode.run_callbacks(:complete) { encode }
+      when :completed
+        encode.run_callbacks(:completed) { encode }
       when :running
         ActiveEncode::PollingJob.set(wait: ActiveEncode::Polling::POLLING_WAIT_TIME).perform_later(encode)
       else # other states are illegal and ignored

--- a/lib/active_encode/polling.rb
+++ b/lib/active_encode/polling.rb
@@ -8,13 +8,13 @@ module ActiveEncode
     POLLING_WAIT_TIME = 10.seconds.freeze
 
     CALLBACKS = [
-        :after_status_update, :after_error, :after_cancelled, :after_complete
+        :after_status_update, :after_failed, :after_cancelled, :after_completed
     ].freeze
 
     included do
       extend ActiveModel::Callbacks
 
-      define_model_callbacks :status_update, :error, :cancelled, :complete, only: :after
+      define_model_callbacks :status_update, :failed, :cancelled, :completed, only: :after
 
       after_create do |encode|
         ActiveEncode::PollingJob.set(wait: POLLING_WAIT_TIME).perform_later(encode)

--- a/spec/units/polling_job_spec.rb
+++ b/spec/units/polling_job_spec.rb
@@ -7,9 +7,9 @@ describe ActiveEncode::PollingJob do
     class PollingEncode < ActiveEncode::Base
       include ActiveEncode::Polling
       after_status_update ->(encode) { encode.history << "PollingEncode ran after_status_update" }
-      after_error ->(encode) { encode.history << "PollingEncode ran after_error" }
+      after_failed ->(encode) { encode.history << "PollingEncode ran after_failed" }
       after_cancelled ->(encode) { encode.history << "PollingEncode ran after_cancelled" }
-      after_complete ->(encode) { encode.history << "PollingEncode ran after_complete" }
+      after_completed ->(encode) { encode.history << "PollingEncode ran after_completed" }
 
       def history
         @history ||= []
@@ -32,12 +32,12 @@ describe ActiveEncode::PollingJob do
       poll.perform(encode)
     end
 
-    context "with job in error" do
-      let(:state) { :error }
+    context "with job failed" do
+      let(:state) { :failed }
 
-      it "runs after_error" do
+      it "runs after_failed" do
         is_expected.to include("PollingEncode ran after_status_update")
-        is_expected.to include("PollingEncode ran after_error")
+        is_expected.to include("PollingEncode ran after_failed")
       end
 
       it "does not re-enqueue itself" do
@@ -58,12 +58,12 @@ describe ActiveEncode::PollingJob do
       end
     end
 
-    context "with job complete" do
-      let(:state) { :complete }
+    context "with job completed" do
+      let(:state) { :completed }
 
-      it "runs after_complete" do
+      it "runs after_completed" do
         is_expected.to include("PollingEncode ran after_status_update")
-        is_expected.to include("PollingEncode ran after_complete")
+        is_expected.to include("PollingEncode ran after_completed")
       end
 
       it "does not re-enqueue itself" do


### PR DESCRIPTION
When testing the ffmpeg adapter in #33, I noticed that the polling module and job are using different state values than expected (see https://github.com/samvera-labs/active_encode/blob/master/lib/active_encode/status.rb).  This PR fixes that issue.