### PR TITLE
JSON get endpoint

### DIFF
--- a/app/controllers/active_encode/encode_record_controller.rb
+++ b/app/controllers/active_encode/encode_record_controller.rb
@@ -1,8 +1,12 @@
 module ActiveEncode
   class EncodeRecordController < ActionController::Base
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      render json: { message: e.message }, status: :not_found
+    end
+
     def show
       @encode_record = ActiveEncode::EncodeRecord.find(params[:id])
-      render json: @encode_record.raw_object
+      render json: @encode_record.raw_object, status: :ok
     end
   end
 end

--- a/app/controllers/active_encode/encode_record_controller.rb
+++ b/app/controllers/active_encode/encode_record_controller.rb
@@ -2,9 +2,7 @@ module ActiveEncode
   class EncodeRecordController < ActionController::Base
     def show
       @encode_record = ActiveEncode::EncodeRecord.find(params[:id])
-      respond_to do |format|
-        format.any { render json: @encode_record.raw_object }
-      end
+      render json: @encode_record.raw_object
     end
   end
 end

--- a/app/controllers/active_encode/encode_record_controller.rb
+++ b/app/controllers/active_encode/encode_record_controller.rb
@@ -1,0 +1,10 @@
+module ActiveEncode
+  class EncodeRecordController < ActionController::Base
+    def show
+      @encode_record = ActiveEncode::EncodeRecord.find(params[:id])
+      respond_to do |format|
+        format.any { render json: @encode_record.raw_object }
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+ActiveEncode::Engine.routes.draw do
+  resources :encode_record, only: [:show]
+end

--- a/spec/controllers/encode_record_controller_spec.rb
+++ b/spec/controllers/encode_record_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe ActiveEncode::EncodeRecordController, type: :controller, db_clean: true do
+  routes { ActiveEncode::Engine.routes }
+
+  let(:encode_record) { ActiveEncode::EncodeRecord.create(id: 1, global_id: "app://ActiveEncode/Encode/1", state: "running", adapter: "ffmpeg", title: "Test", raw_object: raw_object)}
+  let(:raw_object) do
+    "{\"input\":{\"url\":\"file:///Users/cjcolvar/Documents/Code/samvera/active_encode/spec/fixtures/fireworks.mp4\",\"width\":960.0,\"height\":540.0,\"frame_rate\":29.671,\"duration\":6.024,\"file_size\":1629578,\"audio_codec\":\"mp4a-40-2\",\"video_codec\":\"avc1\",\"audio_bitrate\":69737,\"video_bitrate\":2092780,\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:50.401-05:00\",\"id\":\"8156\"},\"options\":{},\"id\":\"35efa965-ec51-409d-9495-2ae9669adbcc\",\"output\":[{\"url\":\"file:///Users/cjcolvar/Documents/Code/samvera/active_encode/.internal_test_app/encodes/35efa965-ec51-409d-9495-2ae9669adbcc/outputs/fireworks-low.mp4\",\"label\":\"low\",\"id\":\"8156-low\",\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:59.169-05:00\",\"width\":640.0,\"height\":480.0,\"frame_rate\":29.671,\"duration\":6.038,\"file_size\":905987,\"audio_codec\":\"mp4a-40-2\",\"video_codec\":\"avc1\",\"audio_bitrate\":72000,\"video_bitrate\":1126859},{\"url\":\"file:///Users/cjcolvar/Documents/Code/samvera/active_encode/.internal_test_app/encodes/35efa965-ec51-409d-9495-2ae9669adbcc/outputs/fireworks-high.mp4\",\"label\":\"high\",\"id\":\"8156-high\",\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:59.169-05:00\",\"width\":1280.0,\"height\":720.0,\"frame_rate\":29.671,\"duration\":6.038,\"file_size\":2102027,\"audio_codec\":\"mp4a-40-2\",\"video_codec\":\"avc1\",\"audio_bitrate\":72000,\"video_bitrate\":2721866}],\"state\":\"completed\",\"errors\":[],\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:59.169-05:00\",\"current_operations\":[],\"percent_complete\":100,\"global_id\":{\"uri\":\"gid://ActiveEncode/Encode/35efa965-ec51-409d-9495-2ae9669adbcc\"}}"
+  end
+
+  before do
+    encode_record
+  end
+
+  describe 'GET show' do
+    it "responds with a 200 status code" do
+      get :show, params: { id: 1 }
+      expect(response.status).to eq 200
+    end
+
+    it "responds with JSON" do
+      get :show, params: { id: 1 }
+      expect(response.content_type).to eq "application/json"
+    end
+
+    it "returns the encode record's raw json object" do
+      get :show, params: { id: 1 }
+      expect(response.body).to eq raw_object
+    end
+  end
+end

--- a/spec/controllers/encode_record_controller_spec.rb
+++ b/spec/controllers/encode_record_controller_spec.rb
@@ -13,19 +13,40 @@ describe ActiveEncode::EncodeRecordController, type: :controller, db_clean: true
   end
 
   describe 'GET show' do
-    it "responds with a 200 status code" do
-      get :show, params: { id: 1 }
-      expect(response.status).to eq 200
+    before do
+      get :show, params: { id: record_id }
     end
 
-    it "responds with JSON" do
-      get :show, params: { id: 1 }
-      expect(response.content_type).to eq "application/json"
+    context 'when record exists' do
+      let(:record_id) { 1 }
+
+      it "responds with a 200 status code" do
+        expect(response.status).to eq 200
+      end
+
+      it "responds with JSON" do
+        expect(response.content_type).to eq "application/json"
+      end
+
+      it "returns the encode record's raw json object" do
+        expect(response.body).to eq raw_object
+      end
     end
 
-    it "returns the encode record's raw json object" do
-      get :show, params: { id: 1 }
-      expect(response.body).to eq raw_object
+    context 'when record does not exist' do
+      let(:record_id) { "non-existant" }
+
+      it "responds with a 404 status code" do
+        expect(response.status).to eq 404
+      end
+
+      it "responds with JSON" do
+        expect(response.content_type).to eq "application/json"
+      end
+
+      it "returns the encode record's raw json object" do
+        expect(response.body).to eq "{\"message\":\"Couldn't find ActiveEncode::EncodeRecord with 'id'=#{record_id}\"}"
+      end
     end
   end
 end

--- a/spec/integration/ffmpeg_adapter_spec.rb
+++ b/spec/integration/ffmpeg_adapter_spec.rb
@@ -8,6 +8,10 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
     Dir.mktmpdir do |dir|
       @dir = dir
       example.run
+      Dir.foreach(dir) do |e|
+        next if e == "." || e == ".."
+        FileUtils.rm_rf(File.join(dir,e))
+      end
     end
 
     ActiveEncode::Base.engine_adapter = :test

--- a/spec/routing/encode_record_controller_routing_spec.rb
+++ b/spec/routing/encode_record_controller_routing_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+describe ActiveEncode::EncodeRecordController, type: :routing do
+  routes { ActiveEncode::Engine.routes }
+
+  it "routes to the show action" do
+    expect(get: encode_record_path(1)).to route_to(controller: "active_encode/encode_record", action: "show", id: "1")
+  end
+end


### PR DESCRIPTION
This PR adds a really simple JSON endpoint.  This is a starting point that will need to evolve as we develop the dashboard and the status display.

I also had to add a hacky workaround to an issue in the ffmpeg adapter specs where `Dir.mktmpdir` was not cleaning itself up at the end of the block but raising not empty errors instead.