### PR TITLE
Persist the options used to create the encode job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,75 +1,13 @@
-require: rubocop-rspec
+inherit_gem:
+  bixby: bixby_default.yml
+
+inherit_from: .rubocop_todo.yml
+
 
 AllCops:
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
+  Exclude:
+    - 'vendor/**/*'
   Include:
     - '**/Rakefile'
-  Exclude:
-    - 'spec/**/*'
-    - 'vendor/**/*'
-
-Rails:
-  Enabled: True
-
-Metrics/LineLength:
-  Enabled: false
-
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/MethodLength:
-  Exclude:
-    - 'lib/active_encode/engine_adapters/*'
-
-Metrics/ClassLength:
-  Exclude:
-    - 'lib/active_encode/engine_adapters/*'
-
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - 'lib/active_encode/engine_adapters/*'
-
-Style/IndentationConsistency:
-  EnforcedStyle: rails
-
-Style/CollectionMethods:
-  PreferredMethods:
-    collect: 'map'
-    collect!: 'map!'
-    inject: 'reduce'
-    detect: 'find'
-    find_all: 'select'
-
-Style/FileName: # https://github.com/bbatsov/rubocop/issues/2973
-  Exclude:
-    - 'Gemfile'
-
-Style/WordArray:
-  Enabled: false
-
-Style/RegexpLiteral:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/ClassAndModuleChildren:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-RSpec/ExampleWording:
-  CustomTransform:
-    be: is
-    have: has
-    not: does not
-    NOT: does NOT
-  IgnoredWords:
-    - only
-
-RSpec/FilePath:
-  Enabled: false
-
-RSpec/InstanceVariable:
-  Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,0 +1,64 @@
+Bundler/DuplicatedGem:
+  Enabled: false
+
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/*'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
+Metrics/BlockNesting:
+  Exclude:
+    - 'lib/file_locator.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/*'
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/ffmpeg_adapter.rb'
+    - 'lib/active_encode/engine_adapters/zencoder_adapter.rb'
+
+Metrics/LineLength:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/matterhorn_adapter.rb'
+    - 'spec/**/*'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/*'
+    - 'lib/file_locator.rb'
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/ffmpeg_adapter.rb'
+    - 'lib/file_locator.rb'
+
+RSpec/AnyInstance:
+  Exclude:
+    - 'spec/integration/ffmpeg_adapter_spec.rb'
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Exclude:
+    - 'spec/integration/ffmpeg_adapter_spec.rb'
+
+RSpec/MessageSpies:
+  Exclude:
+    - 'spec/integration/matterhorn_adapter_spec.rb'
+    - 'spec/integration/ffmpeg_adapter_spec.rb'
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+Style/GuardClause:
+  Exclude:
+    - 'lib/file_locator.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hydra-transcoder.gemspec
@@ -5,8 +6,6 @@ gemspec
 
 gem 'aws-sdk'
 gem 'byebug'
-gem 'rubocop', require: false
-gem 'rubocop-rspec', require: false
 gem 'rubyhorn', git: "https://github.com/avalonmediasystem/rubyhorn.git"
 gem 'shingoncoder'
 gem 'zencoder'
@@ -37,9 +36,9 @@ else
 
   case ENV['RAILS_VERSION']
   when /^4.2/
+    gem 'coffee-rails', '~> 4.1.0'
     gem 'responders', '~> 2.0'
     gem 'sass-rails', '>= 5.0'
-    gem 'coffee-rails', '~> 4.1.0'
   when /^4.[01]/
     gem 'sass-rails', '< 5.0'
   end

--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -10,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Michael Klein, Chris Colvard, Phuong Dinh"]
   spec.email         = ["mbklein@gmail.com, chris.colvard@gmail.com, phuongdh@gmail.com"]
   spec.summary       = 'Declare encode job classes that can be run by a variety of encoding services'
-  spec.description   = 'This gem serves as the basis for the interface between a Ruby (Rails) application and a provider of transcoding services such as Opencast Matterhorn, Zencoder, and Amazon Elastic Transcoder.'
+  spec.description   = 'This gem provides an interface to transcoding services such as Ffmpeg, Amazon Elastic Transcoder, or Zencoder.'
   spec.homepage      = "https://github.com/samvera-labs/active_encode"
   spec.license       = "Apache-2.0"
 
@@ -22,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails"
 
   spec.add_development_dependency "aws-sdk"
+  spec.add_development_dependency "bixby", '~> 1.0.0'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "database_cleaner"

--- a/app/controllers/active_encode/encode_record_controller.rb
+++ b/app/controllers/active_encode/encode_record_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
   class EncodeRecordController < ActionController::Base
     rescue_from ActiveRecord::RecordNotFound do |e|

--- a/app/jobs/active_encode/polling_job.rb
+++ b/app/jobs/active_encode/polling_job.rb
@@ -1,6 +1,6 @@
+# frozen_string_literal: true
 module ActiveEncode
   class PollingJob < ActiveJob::Base
-
     def perform(encode)
       encode.run_callbacks(:status_update) { encode }
       case encode.state

--- a/app/models/active_encode/encode_record.rb
+++ b/app/models/active_encode/encode_record.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
   class EncodeRecord < ActiveRecord::Base
     # sql id, globalid, state, adapter, input filename/job title, timestamps

--- a/db/migrate/20180822021048_create_active_encode_encode_records.rb
+++ b/db/migrate/20180822021048_create_active_encode_encode_records.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateActiveEncodeEncodeRecords < ActiveRecord::Migration[5.0]
   def change
     create_table :active_encode_encode_records do |t|

--- a/db/migrate/20190702153755_add_create_options_to_active_encode_encode_records.rb
+++ b/db/migrate/20190702153755_add_create_options_to_active_encode_encode_records.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddCreateOptionsToActiveEncodeEncodeRecords < ActiveRecord::Migration[5.0]
   def change
     add_column :active_encode_encode_records, :create_options, :text

--- a/db/migrate/20190702153755_add_create_options_to_active_encode_encode_records.rb
+++ b/db/migrate/20190702153755_add_create_options_to_active_encode_encode_records.rb
@@ -1,0 +1,5 @@
+class AddCreateOptionsToActiveEncodeEncodeRecords < ActiveRecord::Migration[5.0]
+  def change
+    add_column :active_encode_encode_records, :create_options, :text
+  end
+end

--- a/lib/active_encode.rb
+++ b/lib/active_encode.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_encode/version'
 require 'active_encode/base'
 require 'active_encode/engine'

--- a/lib/active_encode/base.rb
+++ b/lib/active_encode/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_encode/core'
 require 'active_encode/engine_adapter'
 require 'active_encode/status'

--- a/lib/active_encode/callbacks.rb
+++ b/lib/active_encode/callbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_model/callbacks'
 
 module ActiveEncode

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support'
 require 'active_encode/callbacks'
 
@@ -44,19 +45,19 @@ module ActiveEncode
     end
 
     def initialize(input_url, options = nil)
-      @input = Input.new.tap{ |input| input.url = input_url }
+      @input = Input.new.tap { |input| input.url = input_url }
       @options = self.class.default_options(input_url).merge(Hash(options))
     end
 
     def create!
       run_callbacks :create do
-        merge!(self.class.engine_adapter.create(self.input.url, self.options))
+        merge!(self.class.engine_adapter.create(input.url, options))
       end
     end
 
     def cancel!
       run_callbacks :cancel do
-        merge!(self.class.engine_adapter.cancel(self.id))
+        merge!(self.class.engine_adapter.cancel(id))
       end
     end
 

--- a/lib/active_encode/engine.rb
+++ b/lib/active_encode/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails'
 
 module ActiveEncode

--- a/lib/active_encode/engine_adapter.rb
+++ b/lib/active_encode/engine_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_encode/engine_adapters'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/string/inflections'

--- a/lib/active_encode/engine_adapters.rb
+++ b/lib/active_encode/engine_adapters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
   # == Active Encode adapters
   #
@@ -14,7 +15,7 @@ module ActiveEncode
     autoload :TestAdapter
     autoload :FfmpegAdapter
 
-    ADAPTER = 'Adapter'.freeze
+    ADAPTER = 'Adapter'
     private_constant :ADAPTER
 
     class << self

--- a/lib/active_encode/engine_adapters/matterhorn_adapter.rb
+++ b/lib/active_encode/engine_adapters/matterhorn_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubyhorn'
 
 module ActiveEncode
@@ -11,7 +12,7 @@ module ActiveEncode
         build_encode(get_workflow(workflow_om))
       end
 
-      def find(id, opts = {})
+      def find(id, _opts = {})
         build_encode(fetch_workflow(id))
       end
 
@@ -145,7 +146,7 @@ module ActiveEncode
 
         def convert_created_at(workflow)
           created_at = workflow.xpath('mediapackage/@start').last.to_s
-          created_at.present? ? Time.parse(created_at) : nil
+          created_at.present? ? Time.parse(created_at).utc : nil
         end
 
         def convert_updated_at(workflow)
@@ -156,13 +157,13 @@ module ActiveEncode
         def convert_output_created_at(track, workflow)
           quality = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
           created_at = workflow.xpath("//operation[@id=\"compose\"][configurations/configuration[@key=\"target-tags\" and contains(text(), \"#{quality}\")]]/started/text()").to_s
-          created_at.present? ? Time.at(created_at.to_i / 1000.0) : nil
+          created_at.present? ? Time.at(created_at.to_i / 1000.0).utc : nil
         end
 
         def convert_output_updated_at(track, workflow)
           quality = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
           updated_at = workflow.xpath("//operation[@id=\"compose\"][configurations/configuration[@key=\"target-tags\" and contains(text(), \"#{quality}\")]]/completed/text()").to_s
-          updated_at.present? ? Time.at(updated_at.to_i / 1000.0) : nil
+          updated_at.present? ? Time.at(updated_at.to_i / 1000.0).utc : nil
         end
 
         def convert_options(workflow)

--- a/lib/active_encode/engine_adapters/test_adapter.rb
+++ b/lib/active_encode/engine_adapters/test_adapter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
   module EngineAdapters
     class TestAdapter
@@ -9,8 +10,8 @@ module ActiveEncode
         new_encode = ActiveEncode::Base.new(input_url, options)
         new_encode.id = SecureRandom.uuid
         new_encode.state = :running
-        new_encode.created_at = Time.now
-        new_encode.updated_at = Time.now
+        new_encode.created_at = Time.now.utc
+        new_encode.updated_at = Time.now.utc
         @encodes[new_encode.id] = new_encode
         new_encode
       end
@@ -18,14 +19,14 @@ module ActiveEncode
       def find(id, _opts = {})
         new_encode = @encodes[id]
         # Update the updated_at time to simulate changes
-        new_encode.updated_at = Time.now
+        new_encode.updated_at = Time.now.utc
         new_encode
       end
 
       def cancel(id)
         new_encode = @encodes[id]
         new_encode.state = :cancelled
-        new_encode.updated_at = Time.now
+        new_encode.updated_at = Time.now.utc
         new_encode
       end
     end

--- a/lib/active_encode/engine_adapters/zencoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/zencoder_adapter.rb
@@ -1,13 +1,14 @@
+# frozen_string_literal: true
 module ActiveEncode
   module EngineAdapters
     class ZencoderAdapter
       # TODO: add a stub for an input helper (supplied by an initializer) that transforms encode.input.url into a zencoder accepted url
-      def create(input_url, options = {})
+      def create(input_url, _options = {})
         response = Zencoder::Job.create(input: input_url.to_s)
         build_encode(get_job_details(response.body["id"]))
       end
 
-      def find(id, opts = {})
+      def find(id, _opts = {})
         build_encode(get_job_details(id))
       end
 

--- a/lib/active_encode/global_id.rb
+++ b/lib/active_encode/global_id.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'globalid'
 
 module ActiveEncode
@@ -9,7 +10,7 @@ module ActiveEncode
       other.is_a?(ActiveEncode::Base) && to_global_id == other.to_global_id
     end
 
-    def to_global_id(options = {})
+    def to_global_id(_options = {})
       super(app: 'ActiveEncode')
     end
   end

--- a/lib/active_encode/input.rb
+++ b/lib/active_encode/input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
   class Input
     include Status
@@ -8,8 +9,8 @@ module ActiveEncode
 
     def valid?
       id.present? && url.present? &&
-      created_at.is_a?(Time) && updated_at.is_a?(Time) &&
-      updated_at >= created_at
+        created_at.is_a?(Time) && updated_at.is_a?(Time) &&
+        updated_at >= created_at
     end
   end
 end

--- a/lib/active_encode/output.rb
+++ b/lib/active_encode/output.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
   class Output
     include Status
@@ -9,8 +10,8 @@ module ActiveEncode
 
     def valid?
       id.present? && url.present? && label.present? &&
-      created_at.is_a?(Time) && updated_at.is_a?(Time) &&
-      updated_at >= created_at
+        created_at.is_a?(Time) && updated_at.is_a?(Time) &&
+        updated_at >= created_at
     end
   end
 end

--- a/lib/active_encode/persistence.rb
+++ b/lib/active_encode/persistence.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support'
 
 module ActiveEncode

--- a/lib/active_encode/persistence.rb
+++ b/lib/active_encode/persistence.rb
@@ -9,8 +9,10 @@ module ActiveEncode
         persist(persistence_model_attributes(encode))
       end
 
-      after_create do |encode|
-        persist(persistence_model_attributes(encode))
+      around_create do |encode, block|
+        create_options = encode.options
+        encode = block.call
+        persist(persistence_model_attributes(encode).merge(create_options: create_options.to_json))
       end
 
       after_cancel do |encode|

--- a/lib/active_encode/polling.rb
+++ b/lib/active_encode/polling.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support'
 require 'active_model/callbacks'
 
@@ -8,7 +9,7 @@ module ActiveEncode
     POLLING_WAIT_TIME = 10.seconds.freeze
 
     CALLBACKS = [
-        :after_status_update, :after_failed, :after_cancelled, :after_completed
+      :after_status_update, :after_failed, :after_cancelled, :after_completed
     ].freeze
 
     included do

--- a/lib/active_encode/status.rb
+++ b/lib/active_encode/status.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support'
 
 module ActiveEncode

--- a/lib/active_encode/technical_metadata.rb
+++ b/lib/active_encode/technical_metadata.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support'
 
 module ActiveEncode
@@ -23,10 +24,10 @@ module ActiveEncode
       attr_accessor :video_bitrate
     end
 
-    def assign_tech_metadata metadata
+    def assign_tech_metadata(metadata)
       [:width, :height, :frame_rate, :duration, :file_size, :checksum,
        :audio_codec, :video_codec, :audio_bitrate, :video_bitrate].each do |field|
-         self.send("#{field}=", metadata[field]) if metadata.has_key?(field)
+        send("#{field}=", metadata[field]) if metadata.key?(field)
       end
     end
   end

--- a/lib/active_encode/version.rb
+++ b/lib/active_encode/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ActiveEncode
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.5.0'
 end

--- a/lib/file_locator.rb
+++ b/lib/file_locator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'addressable/uri'
 require 'aws-sdk'
 
@@ -10,7 +11,7 @@ class FileLocator
     def initialize(uri)
       uri = Addressable::URI.parse(uri)
       @bucket = URI.decode(uri.host)
-      @key = URI.decode(uri.path).sub(%r(^/*(.+)/*$),'\1')
+      @key = URI.decode(uri.path).sub(%r{^/*(.+)/*$}, '\1')
     end
 
     def object
@@ -39,9 +40,7 @@ class FileLocator
           end
         end
 
-        if @uri.scheme.nil?
-          @uri = Addressable::URI.parse("file://#{URI.encode(File.expand_path(source))}")
-        end
+        @uri = Addressable::URI.parse("file://#{URI.encode(File.expand_path(source))}") if @uri.scheme.nil?
       end
     end
     @uri
@@ -68,16 +67,16 @@ class FileLocator
       false
     end
   end
-  alias_method :exists?, :exist?
+  alias exists? exist?
 
   def reader
     case uri.scheme
     when 's3'
       S3File.new(uri).object.get.body
     when 'file'
-      File.open(location,'r')
+      File.open(location, 'r')
     else
-      Kernel::open(uri.to_s, 'r')
+      Kernel.open(uri.to_s, 'r')
     end
   end
 
@@ -86,7 +85,7 @@ class FileLocator
     when 's3'
       uri
     when 'file'
-      File.open(location,'r')
+      File.open(location, 'r')
     else
       location
     end

--- a/spec/controllers/encode_record_controller_spec.rb
+++ b/spec/controllers/encode_record_controller_spec.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe ActiveEncode::EncodeRecordController, type: :controller, db_clean: true do
   routes { ActiveEncode::Engine.routes }
 
-  let(:encode_record) { ActiveEncode::EncodeRecord.create(id: 1, global_id: "app://ActiveEncode/Encode/1", state: "running", adapter: "ffmpeg", title: "Test", raw_object: raw_object)}
+  let(:encode_record) { ActiveEncode::EncodeRecord.create(id: 1, global_id: "app://ActiveEncode/Encode/1", state: "running", adapter: "ffmpeg", title: "Test", raw_object: raw_object) }
   let(:raw_object) do
     "{\"input\":{\"url\":\"file:///Users/cjcolvar/Documents/Code/samvera/active_encode/spec/fixtures/fireworks.mp4\",\"width\":960.0,\"height\":540.0,\"frame_rate\":29.671,\"duration\":6024,\"file_size\":1629578,\"audio_codec\":\"mp4a-40-2\",\"video_codec\":\"avc1\",\"audio_bitrate\":69737,\"video_bitrate\":2092780,\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:50.401-05:00\",\"id\":\"8156\"},\"options\":{},\"id\":\"35efa965-ec51-409d-9495-2ae9669adbcc\",\"output\":[{\"url\":\"file:///Users/cjcolvar/Documents/Code/samvera/active_encode/.internal_test_app/encodes/35efa965-ec51-409d-9495-2ae9669adbcc/outputs/fireworks-low.mp4\",\"label\":\"low\",\"id\":\"8156-low\",\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:59.169-05:00\",\"width\":640.0,\"height\":480.0,\"frame_rate\":29.671,\"duration\":6038,\"file_size\":905987,\"audio_codec\":\"mp4a-40-2\",\"video_codec\":\"avc1\",\"audio_bitrate\":72000,\"video_bitrate\":1126859},{\"url\":\"file:///Users/cjcolvar/Documents/Code/samvera/active_encode/.internal_test_app/encodes/35efa965-ec51-409d-9495-2ae9669adbcc/outputs/fireworks-high.mp4\",\"label\":\"high\",\"id\":\"8156-high\",\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:59.169-05:00\",\"width\":1280.0,\"height\":720.0,\"frame_rate\":29.671,\"duration\":6038,\"file_size\":2102027,\"audio_codec\":\"mp4a-40-2\",\"video_codec\":\"avc1\",\"audio_bitrate\":72000,\"video_bitrate\":2721866}],\"state\":\"completed\",\"errors\":[],\"created_at\":\"2018-12-17T16:54:50.401-05:00\",\"updated_at\":\"2018-12-17T16:54:59.169-05:00\",\"current_operations\":[],\"percent_complete\":100,\"global_id\":{\"uri\":\"gid://ActiveEncode/Encode/35efa965-ec51-409d-9495-2ae9669adbcc\"}}"
   end

--- a/spec/integration/elastic_transcoder_adapter_spec.rb
+++ b/spec/integration/elastic_transcoder_adapter_spec.rb
@@ -1,10 +1,11 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'aws-sdk'
 require 'json'
 require 'shared_specs/engine_adapter_specs'
 
 describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
-  around(:example) do |example|
+  around do |example|
     # Setting this before each test works around a stubbing + memoization limitation
     ActiveEncode::Base.engine_adapter = :elastic_transcoder
     example.run
@@ -22,26 +23,27 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
   let(:created_job) do
     j = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_created.json'))
     j.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_generic.json')))
-    j.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_submitted.json')))]
+    j.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_submitted.json')))]
 
     client.stub_responses(:create_job, Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j))
 
     ActiveEncode::Base.create(
-     "spec/fixtures/fireworks.mp4",
-     pipeline_id: "1471963629141-kmcocm",
-     masterfile_bucket: "BucketName",
-     output_key_prefix: "elastic-transcoder-samples/output/hls/",
-     outputs: [{
-       key: 'hls0400k/' + "e8fe80f5bsomefilesource_bucket7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a",
-       preset_id: "1351620000001-200050",
-       segment_duration: "2",
-     }])
+      "spec/fixtures/fireworks.mp4",
+      pipeline_id: "1471963629141-kmcocm",
+      masterfile_bucket: "BucketName",
+      output_key_prefix: "elastic-transcoder-samples/output/hls/",
+      outputs: [{
+        key: 'hls0400k/' + "e8fe80f5bsomefilesource_bucket7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a",
+        preset_id: "1351620000001-200050",
+        segment_duration: "2"
+      }]
+    )
   end
 
   let(:running_job) do
     j = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_progressing.json'))
     j.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_progressing.json')))
-    j.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_progressing.json')))]
+    j.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_progressing.json')))]
 
     client.stub_responses(:read_job, Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j))
     ActiveEncode::Base.find('running-id')
@@ -50,7 +52,7 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
   let(:canceled_job) do
     j = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_canceled.json'))
     j.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_generic.json')))
-    j.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_canceled.json')))]
+    j.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_canceled.json')))]
 
     client.stub_responses(:read_job, Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j))
 
@@ -60,11 +62,11 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
   let(:cancelling_job) do
     j1 = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_progressing.json'))
     j1.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_progressing.json')))
-    j1.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_progressing.json')))]
+    j1.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_progressing.json')))]
 
     j2 = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_canceled.json'))
     j2.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_generic.json')))
-    j2.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_canceled.json')))]
+    j2.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_canceled.json')))]
 
     client.stub_responses(:read_job, [Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j1), Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j2)])
 
@@ -78,7 +80,7 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
   let(:completed_job) do
     j = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_completed.json'))
     j.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_completed.json')))
-    j.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_completed.json')))]
+    j.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_completed.json')))]
 
     client.stub_responses(:read_job, Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j))
     ActiveEncode::Base.find('completed-id')
@@ -87,29 +89,28 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
   let(:failed_job) do
     j = Aws::ElasticTranscoder::Types::Job.new JSON.parse(File.read('spec/fixtures/elastic_transcoder/job_failed.json'))
     j.input = Aws::ElasticTranscoder::Types::JobInput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/input_generic.json')))
-    j.outputs = [ Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_failed.json')))]
+    j.outputs = [Aws::ElasticTranscoder::Types::JobOutput.new(JSON.parse(File.read('spec/fixtures/elastic_transcoder/output_failed.json')))]
 
     client.stub_responses(:read_job, Aws::ElasticTranscoder::Types::ReadJobResponse.new(job: j))
     ActiveEncode::Base.find('failed-id')
   end
 
-  let(:completed_output) { [{ id: "2", url: "s3://BucketName/elastic-transcoder-samples/output/hls/hls0400k/e8fe80f5b7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a", label: "hls0400k", :width=>400, :height=>224, :frame_rate=>25, :file_size=>6901104, :duration=>117353 }] }
-  let(:completed_tech_metadata) { { :width=>1280, :height=>720, :frame_rate=>25, :file_size=>21069678, :duration=>117312 } }
+  let(:completed_output) { [{ id: "2", url: "s3://BucketName/elastic-transcoder-samples/output/hls/hls0400k/e8fe80f5b7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a", label: "hls0400k", width: 400, height: 224, frame_rate: 25, file_size: 6_901_104, duration: 117_353 }] }
+  let(:completed_tech_metadata) { { width: 1280, height: 720, frame_rate: 25, file_size: 21_069_678, duration: 117_312 } }
   let(:failed_tech_metadata) { {} }
 
   it_behaves_like "an ActiveEncode::EngineAdapter"
 
   describe "#create" do
-    let(:create_output) { [{ id: "2", url: "s3://BucketName/elastic-transcoder-samples/output/hls/hls0400k/e8fe80f5b7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a", label: "hls0400k" }] }
-
     subject { created_job }
+    let(:create_output) { [{ id: "2", url: "s3://BucketName/elastic-transcoder-samples/output/hls/hls0400k/e8fe80f5b7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a", label: "hls0400k" }] }
 
     it { is_expected.to be_running }
     its(:current_operations) { is_expected.to be_empty }
 
     it 'output has technical metadata' do
       subject.output.each do |output|
-        expected_output = create_output.find {|expected_out| expected_out[:id] == output.id }
+        expected_output = create_output.find { |expected_out| expected_out[:id] == output.id }
         expect(output.as_json.symbolize_keys).to include expected_output
       end
     end
@@ -117,10 +118,9 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
 
   describe "#find" do
     context "a running encode" do
-      let(:running_output) { [{ id: "2", url: "s3://BucketName/elastic-transcoder-samples/output/hls/hls0400k/e8fe80f5b7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a", label: "hls0400k" }] }
-      let(:running_tech_metadata) { {:width=>1280, :height=>720, :frame_rate=>25, :file_size=>21069678, :duration=>117312} }
-
       subject { running_job }
+      let(:running_output) { [{ id: "2", url: "s3://BucketName/elastic-transcoder-samples/output/hls/hls0400k/e8fe80f5b7063b12d567b90c0bdf6322116bba11ac458fe9d62921644159fe4a", label: "hls0400k" }] }
+      let(:running_tech_metadata) { { width: 1280, height: 720, frame_rate: 25, file_size: 21_069_678, duration: 117_312 } }
 
       its(:current_operations) { is_expected.to be_empty }
 
@@ -130,7 +130,7 @@ describe ActiveEncode::EngineAdapters::ElasticTranscoderAdapter do
 
       it 'output has technical metadata' do
         subject.output.each do |output|
-          expected_output = running_output.find {|expected_out| expected_out[:id] == output.id }
+          expected_output = running_output.find { |expected_out| expected_out[:id] == output.id }
           expect(output.as_json.symbolize_keys).to include expected_output
         end
       end

--- a/spec/integration/ffmpeg_adapter_spec.rb
+++ b/spec/integration/ffmpeg_adapter_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'shared_specs/engine_adapter_specs'
 
 describe ActiveEncode::EngineAdapters::FfmpegAdapter do
-  around(:example) do |example|
+  around do |example|
     ActiveEncode::Base.engine_adapter = :ffmpeg
 
     Dir.mktmpdir do |dir|
@@ -10,7 +11,7 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
       example.run
       Dir.foreach(dir) do |e|
         next if e == "." || e == ".."
-        FileUtils.rm_rf(File.join(dir,e))
+        FileUtils.rm_rf(File.join(dir, e))
       end
     end
 
@@ -18,9 +19,9 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
   end
 
   let!(:work_dir) { stub_const "ActiveEncode::EngineAdapters::FfmpegAdapter::WORK_DIR", @dir }
-  let(:file) { "file://#{File.absolute_path "spec/fixtures/fireworks.mp4"}" }
+  let(:file) { "file://#{File.absolute_path 'spec/fixtures/fireworks.mp4'}" }
   let(:created_job) do
-    ActiveEncode::Base.create(file, { outputs: [{ label: "low", ffmpeg_opt: "-s 640x480", extension: "mp4"}, { label: "high", ffmpeg_opt: "-s 1280x720", extension: "mp4"}] })
+    ActiveEncode::Base.create(file, outputs: [{ label: "low", ffmpeg_opt: "-s 640x480", extension: "mp4" }, { label: "high", ffmpeg_opt: "-s 1280x720", extension: "mp4" }])
   end
   let(:running_job) do
     allow(Process).to receive(:getpgid).and_return 8888
@@ -35,24 +36,27 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
   end
   let(:completed_job) { find_encode "completed-id" }
   let(:failed_job) { find_encode 'failed-id' }
-  let(:completed_tech_metadata) { {:audio_bitrate => 171030,
-    :audio_codec => 'mp4a-40-2',
-    :duration => 6315,
-    :file_size => 199160,
-    :frame_rate => 23.719,
-    :height => 110.0,
-    :id => "99999",
-    :url => "/home/pdinh/Downloads/videoshort.mp4",
-    :video_bitrate => 74477,
-    :video_codec => 'avc1',
-    :width => 200.0
-  } }
+  let(:completed_tech_metadata) do
+    {
+      audio_bitrate: 171_030,
+      audio_codec: 'mp4a-40-2',
+      duration: 6315,
+      file_size: 199_160,
+      frame_rate: 23.719,
+      height: 110.0,
+      id: "99999",
+      url: "/home/pdinh/Downloads/videoshort.mp4",
+      video_bitrate: 74_477,
+      video_codec: 'avc1',
+      width: 200.0
+    }
+  end
   let(:completed_output) { [{ id: "99999" }] }
-  let(:failed_tech_metadata) { { } }
+  let(:failed_tech_metadata) { {} }
 
   it_behaves_like "an ActiveEncode::EngineAdapter"
 
-  def find_encode id
+  def find_encode(id)
     # Precreate ffmpeg output directory and files
     FileUtils.copy_entry "spec/fixtures/ffmpeg/#{id}", "#{work_dir}/#{id}"
 
@@ -61,7 +65,7 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
     FileUtils.touch "#{work_dir}/#{id}/progress"
     FileUtils.touch Dir.glob("#{work_dir}/#{id}/*.mp4")
 
-    # # Stub out system calls
+    # Stub out system calls
     allow_any_instance_of(ActiveEncode::EngineAdapters::FfmpegAdapter).to receive(:`).and_return(1234)
 
     ActiveEncode::Base.find(id)
@@ -86,7 +90,7 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
 
     context "input file doesn't exist" do
       let(:missing_file) { "file:///a_bogus_file.mp4" }
-      let(:missing_job) { ActiveEncode::Base.create(missing_file, { outputs: [{ label: "low", ffmpeg_opt: "-s 640x480", extension: 'mp4' }]}) }
+      let(:missing_job) { ActiveEncode::Base.create(missing_file, outputs: [{ label: "low", ffmpeg_opt: "-s 640x480", extension: 'mp4' }]) }
 
       it "returns the encode with correct error" do
         expect(missing_job.errors).to include("#{missing_file} does not exist or is not accessible")
@@ -95,8 +99,8 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
     end
 
     context "input file is not media" do
-      let(:nonmedia_file) { "file://#{File.absolute_path "spec/integration/ffmpeg_adapter_spec.rb"}" }
-      let(:nonmedia_job) { ActiveEncode::Base.create(nonmedia_file, { outputs: [{ label: "low", ffmpeg_opt: "-s 640x480", extension: 'mp4' }]}) }
+      let(:nonmedia_file) { "file://#{File.absolute_path 'spec/integration/ffmpeg_adapter_spec.rb'}" }
+      let(:nonmedia_job) { ActiveEncode::Base.create(nonmedia_file, outputs: [{ label: "low", ffmpeg_opt: "-s 640x480", extension: 'mp4' }]) }
 
       it "returns the encode with correct error" do
         expect(nonmedia_job.errors).to include("Error inspecting input: #{nonmedia_file}")

--- a/spec/integration/matterhorn_adapter_spec.rb
+++ b/spec/integration/matterhorn_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'rubyhorn'
 require 'shared_specs/engine_adapter_specs'
@@ -26,13 +27,13 @@ describe ActiveEncode::EngineAdapters::MatterhornAdapter do
   let(:created_job) { ActiveEncode::Base.create(file) }
   let(:running_job) { ActiveEncode::Base.find('running-id') }
   let(:canceled_job) { ActiveEncode::Base.find('cancelled-id') }
-  let(:cancelling_job) { ActiveEncode::Base.find('running-id')}
+  let(:cancelling_job) { ActiveEncode::Base.find('running-id') }
   let(:completed_job) { ActiveEncode::Base.find('completed-id') }
   let(:failed_job) { ActiveEncode::Base.find('failed-id') }
 
-  let(:completed_output) { [{ id: "track-7", checksum: "77de9765545ef63d2c21f7557ead6176", duration: 6337, audio_codec: "AAC", audio_bitrate: 76502.0, video_codec: "AVC", video_bitrate: 2000000.0, frame_rate: 30.0, width: 1308, height: 720, url: "file:///home/cjcolvar/Code/avalon/avalon/red5/webapps/avalon/streams/f564d9de-9c35-4b74-95f0-f3013f32cc1a/b09c765f-b64e-4725-a863-736af66b688c/videoshort.mp4", label: "quality-high" }, { id: "track-8", checksum: "10e13cf51bf8a973011eec6a17ea47ff", duration: 6337, audio_codec: "AAC", audio_bitrate: 76502.0, video_codec: "AVC", video_bitrate: 500000.0, frame_rate: 30.0, width: 654, height: 360, url: "file:///home/cjcolvar/Code/avalon/avalon/red5/webapps/avalon/streams/f564d9de-9c35-4b74-95f0-f3013f32cc1a/8d5cd8a9-ad0e-484a-96f0-05e26a84a8f0/videoshort.mp4", label: "quality-low" }, { id: "track-9", checksum: "f2b16a2606dc76cb53c7017f0e166204", duration: 6337, audio_codec: "AAC", audio_bitrate: 76502.0, video_codec: "AVC", video_bitrate: 1000000.0, frame_rate: 30.0, width: 872, height: 480, url: "file:///home/cjcolvar/Code/avalon/avalon/red5/webapps/avalon/streams/f564d9de-9c35-4b74-95f0-f3013f32cc1a/0f81d426-0e26-4496-8f58-c675c86e6f4e/videoshort.mp4", label: "quality-medium" }] }
-  let(:completed_tech_metadata) { { } }
-  let(:failed_tech_metadata) { { checksum: "7ae24368ccb7a6c6422a14ff73f33c9a", duration: 6314, audio_codec: "AAC", audio_bitrate: 171030.0, video_codec: "AVC", video_bitrate: 74477.0, frame_rate: 23.719, width: 200, height: 110 } }
+  let(:completed_output) { [{ id: "track-7", checksum: "77de9765545ef63d2c21f7557ead6176", duration: 6337, audio_codec: "AAC", audio_bitrate: 76_502.0, video_codec: "AVC", video_bitrate: 2_000_000.0, frame_rate: 30.0, width: 1308, height: 720, url: "file:///home/cjcolvar/Code/avalon/avalon/red5/webapps/avalon/streams/f564d9de-9c35-4b74-95f0-f3013f32cc1a/b09c765f-b64e-4725-a863-736af66b688c/videoshort.mp4", label: "quality-high" }, { id: "track-8", checksum: "10e13cf51bf8a973011eec6a17ea47ff", duration: 6337, audio_codec: "AAC", audio_bitrate: 76_502.0, video_codec: "AVC", video_bitrate: 500_000.0, frame_rate: 30.0, width: 654, height: 360, url: "file:///home/cjcolvar/Code/avalon/avalon/red5/webapps/avalon/streams/f564d9de-9c35-4b74-95f0-f3013f32cc1a/8d5cd8a9-ad0e-484a-96f0-05e26a84a8f0/videoshort.mp4", label: "quality-low" }, { id: "track-9", checksum: "f2b16a2606dc76cb53c7017f0e166204", duration: 6337, audio_codec: "AAC", audio_bitrate: 76_502.0, video_codec: "AVC", video_bitrate: 1_000_000.0, frame_rate: 30.0, width: 872, height: 480, url: "file:///home/cjcolvar/Code/avalon/avalon/red5/webapps/avalon/streams/f564d9de-9c35-4b74-95f0-f3013f32cc1a/0f81d426-0e26-4496-8f58-c675c86e6f4e/videoshort.mp4", label: "quality-medium" }] }
+  let(:completed_tech_metadata) { {} }
+  let(:failed_tech_metadata) { { checksum: "7ae24368ccb7a6c6422a14ff73f33c9a", duration: 6314, audio_codec: "AAC", audio_bitrate: 171_030.0, video_codec: "AVC", video_bitrate: 74_477.0, frame_rate: 23.719, width: 200, height: 110 } }
   let(:failed_errors) { "org.opencastproject.workflow.api.WorkflowOperationException: org.opencastproject.workflow.api.WorkflowOperationException: One of the encoding jobs did not complete successfully" }
 
   # Enforce generic behavior
@@ -92,8 +93,8 @@ describe ActiveEncode::EngineAdapters::MatterhornAdapter do
   end
 
   describe "#cancel!" do
-    let(:encode) { ActiveEncode::Base.create(file) }
     subject { encode.cancel! }
+    let(:encode) { ActiveEncode::Base.create(file) }
 
     it { is_expected.to be_a ActiveEncode::Base }
     its(:id) { is_expected.to eq 'cancelled-id' }

--- a/spec/integration/zencoder_adapter_spec.rb
+++ b/spec/integration/zencoder_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 require 'zencoder'
 require 'json'
@@ -24,11 +25,11 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
       allow(Zencoder::Job).to receive(:progress).and_return(progress_response)
     end
 
+    subject { ActiveEncode::Base.create(file) }
     let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_create.json'))) }
     let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_create.json'))) }
     let(:create_output) { [{ id: "511404522", url: "https://zencoder-temp-storage-us-east-1.s3.amazonaws.com/o/20150610/c09b61e4d130ddf923f0653418a80b9c/399ae101c3f99b4f318635e78a4e587a.mp4?AWSAccessKeyId=AKIAI456JQ76GBU7FECA&Signature=GY/9LMkQAiDOrMQwS5BkmOE200s%3D&Expires=1434033527", label: nil }] }
 
-    subject { ActiveEncode::Base.create(file) }
     it { is_expected.to be_a ActiveEncode::Base }
     its(:id) { is_expected.not_to be_empty }
     it { is_expected.to be_running }
@@ -61,8 +62,8 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
     end
 
     context 'output' do
-      let(:output) { ActiveEncode::Base.find('166019107').reload.output }
       subject { output.first }
+      let(:output) { ActiveEncode::Base.find('166019107').reload.output }
 
       it 'is an array' do
         expect(output).to be_a Array
@@ -94,12 +95,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
     end
 
     context "a running encode" do
+      subject { ActiveEncode::Base.find('166019107') }
       let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_running.json'))) }
       let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_running.json'))) }
       # let(:running_output) { [{ id: "510582971", url: "https://zencoder-temp-storage-us-east-1.s3.amazonaws.com/o/20150609/48a6907086c012f68b9ca43461280515/1726d7ec3e24f2171bd07b2abb807b6c.mp4?AWSAccessKeyId=AKIAI456JQ76GBU7FECA&Signature=vSvlxU94wlQLEbpG3Zs8ibp4MoY%3D&Expires=1433953106", label: nil }] }
       # let(:running_tech_metadata) { { audio_bitrate: "52", audio_codec: "aac", audio_channels: "2", duration: "57992", mime_type: "mpeg4", video_framerate: "29.97", height: "240", video_bitrate: "535", video_codec: "h264", width: "320" } }
 
-      subject { ActiveEncode::Base.find('166019107') }
       it { is_expected.to be_a ActiveEncode::Base }
       its(:id) { is_expected.to eq '166019107' }
       it { is_expected.to be_running }
@@ -120,7 +121,7 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
         its(:width) { is_expected.to eq 320 }
         its(:height) { is_expected.to eq 240 }
         its(:frame_rate) { is_expected.to eq 29.97 }
-        its(:duration) { is_expected.to eq 57992 }
+        its(:duration) { is_expected.to eq 57_992 }
         its(:file_size) { is_expected.to be_blank }
         its(:checksum) { is_expected.to be_blank }
         its(:audio_codec) { is_expected.to eq "aac" }
@@ -133,8 +134,8 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
       end
 
       context 'output' do
-        let(:output) { ActiveEncode::Base.find('166019107').output }
         subject { output.first }
+        let(:output) { ActiveEncode::Base.find('166019107').output }
 
         it 'is an array' do
           expect(output).to be_a Array
@@ -160,10 +161,10 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
     end
 
     context "a cancelled encode" do
+      subject { ActiveEncode::Base.find('165866551') }
       let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_cancelled.json'))) }
       let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_cancelled.json'))) }
 
-      subject { ActiveEncode::Base.find('165866551') }
       it { is_expected.to be_a ActiveEncode::Base }
       its(:id) { is_expected.to eq '165866551' }
       it { is_expected.to be_cancelled }
@@ -196,12 +197,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
     end
 
     context "a completed encode" do
+      subject { ActiveEncode::Base.find('165839139') }
       let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_completed.json'))) }
       let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_completed.json'))) }
       let(:completed_output) { { id: "509856876", audio_bitrate: "53", audio_codec: "aac", audio_channels: "2", duration: "5000", mime_type: "mpeg4", video_framerate: "29.97", height: "240", video_bitrate: "549", video_codec: "h264", width: "320", url: "https://zencoder-temp-storage-us-east-1.s3.amazonaws.com/o/20150608/ebbe865f8ef1b960d7c2bb0663b88a12/0f1948dcb2fd701fba30ff21908fe460.mp4?AWSAccessKeyId=AKIAI456JQ76GBU7FECA&Signature=1LgIyl/el9E7zeyPxzd/%2BNwez6Y%3D&Expires=1433873646", label: nil } }
       # let(:completed_tech_metadata) { { audio_bitrate: "52", audio_codec: "aac", audio_channels: "2", duration: "57992", mime_type: "mpeg4", video_framerate: "29.97", height: "240", video_bitrate: "535", video_codec: "h264", width: "320" } }
 
-      subject { ActiveEncode::Base.find('165839139') }
       it { is_expected.to be_a ActiveEncode::Base }
       its(:id) { is_expected.to eq '165839139' }
       it { is_expected.to be_completed }
@@ -221,7 +222,7 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
         its(:width) { is_expected.to eq 320 }
         its(:height) { is_expected.to eq 240 }
         its(:frame_rate) { is_expected.to eq 29.97 }
-        its(:duration) { is_expected.to eq 57992 }
+        its(:duration) { is_expected.to eq 57_992 }
         its(:file_size) { is_expected.to be_blank }
         its(:checksum) { is_expected.to be_blank }
         its(:audio_codec) { is_expected.to eq "aac" }
@@ -234,8 +235,8 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
       end
 
       context 'output' do
-        let(:output) { ActiveEncode::Base.find('166019107').reload.output }
         subject { output.first }
+        let(:output) { ActiveEncode::Base.find('166019107').reload.output }
 
         it 'is an array' do
           expect(output).to be_a Array
@@ -261,12 +262,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
     end
 
     context "a failed encode" do
+      subject { ActiveEncode::Base.find('166079902') }
       let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_failed.json'))) }
       let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_failed.json'))) }
       let(:failed_tech_metadata) { { mime_type: "video/mp4", checksum: "7ae24368ccb7a6c6422a14ff73f33c9a", duration: "6314", audio_codec: "AAC", audio_channels: "2", audio_bitrate: "171030.0", video_codec: "AVC", video_bitrate: "74477.0", video_framerate: "23.719", width: "200", height: "110" } }
       let(:failed_errors) { "The file is an XML file, and doesn't contain audio or video tracks." }
 
-      subject { ActiveEncode::Base.find('166079902') }
       it { is_expected.to be_a ActiveEncode::Base }
       its(:id) { is_expected.to eq '166079902' }
       it { is_expected.to be_failed }
@@ -307,12 +308,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
       allow(Zencoder::Job).to receive(:progress).and_return(progress_response)
     end
 
+    subject { encode.cancel! }
     let(:cancel_response) { Zencoder::Response.new(code: 200) } # TODO: check that this is the correct response code for a successful cancel
     let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_cancelled.json'))) }
     let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_cancelled.json'))) }
 
     let(:encode) { ActiveEncode::Base.create(file) }
-    subject { encode.cancel! }
     it { is_expected.to be_a ActiveEncode::Base }
     its(:id) { is_expected.to eq '165866551' }
     it { is_expected.to be_cancelled }
@@ -324,12 +325,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
       allow(Zencoder::Job).to receive(:progress).and_return(progress_response)
     end
 
+    subject { ActiveEncode::Base.find('166019107').reload }
     let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_running.json'))) }
     let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_running.json'))) }
     # let(:reload_output) { [{ id: "510582971", url: "https://zencoder-temp-storage-us-east-1.s3.amazonaws.com/o/20150609/48a6907086c012f68b9ca43461280515/1726d7ec3e24f2171bd07b2abb807b6c.mp4?AWSAccessKeyId=AKIAI456JQ76GBU7FECA&Signature=vSvlxU94wlQLEbpG3Zs8ibp4MoY%3D&Expires=1433953106", label: nil }] }
     # let(:reload_tech_metadata) { { audio_bitrate: "52", audio_codec: "aac", audio_channels: "2", duration: "57992", mime_type: "mpeg4", video_framerate: "29.97", height: "240", video_bitrate: "535", video_codec: "h264", width: "320" } }
 
-    subject { ActiveEncode::Base.find('166019107').reload }
     it { is_expected.to be_a ActiveEncode::Base }
     its(:id) { is_expected.to eq '166019107' }
     it { is_expected.to be_running }
@@ -349,7 +350,7 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
       its(:width) { is_expected.to eq 320 }
       its(:height) { is_expected.to eq 240 }
       its(:frame_rate) { is_expected.to eq 29.97 }
-      its(:duration) { is_expected.to eq 57992 }
+      its(:duration) { is_expected.to eq 57_992 }
       its(:file_size) { is_expected.to be_blank }
       its(:checksum) { is_expected.to be_blank }
       its(:audio_codec) { is_expected.to eq "aac" }
@@ -362,8 +363,8 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
     end
 
     context 'output' do
-      let(:output) { ActiveEncode::Base.find('166019107').reload.output }
       subject { output.first }
+      let(:output) { ActiveEncode::Base.find('166019107').reload.output }
 
       it 'is an array' do
         expect(output).to be_a Array

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 require 'engine_cart'

--- a/spec/routing/encode_record_controller_routing_spec.rb
+++ b/spec/routing/encode_record_controller_routing_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe ActiveEncode::EncodeRecordController, type: :routing do

--- a/spec/shared_specs/engine_adapter_specs.rb
+++ b/spec/shared_specs/engine_adapter_specs.rb
@@ -130,7 +130,7 @@ RSpec.shared_examples 'an ActiveEncode::EngineAdapter' do |*_flags|
 
       it 'output has technical metadata' do
         subject.output.each do |output|
-          expected_output = completed_output.find {|expected_out| expected_out[:id] == output.id }
+          expected_output = completed_output.find { |expected_out| expected_out[:id] == output.id }
           expect(output.as_json.symbolize_keys).to include expected_output
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'coveralls'
 Coveralls.wear!
 
@@ -13,6 +14,6 @@ end
 
 RSpec::Matchers.define :be_the_same_time_as do |expected|
   match do |actual|
-    expect(Time.parse(expected)).to eq(Time.parse(actual))
+    expect(Time.parse(expected).utc).to eq(Time.parse(actual).utc)
   end
 end

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -1,15 +1,16 @@
-        require 'rails/generators'
+# frozen_string_literal: true
+# frozen_string_literal: true
+require 'rails/generators'
 
-        class TestAppGenerator < Rails::Generators::Base
-          source_root "./spec/test_app_templates"
+class TestAppGenerator < Rails::Generators::Base
+  source_root "./spec/test_app_templates"
 
-          # if you need to generate any additional configuration
-          # into the test app, this generator will be run immediately
-          # after setting up the application
+  # if you need to generate any additional configuration
+  # into the test app, this generator will be run immediately
+  # after setting up the application
 
-          def install_engine
-            generate 'active_encode:install'
-            rake 'active_encode:install:migrations'
-          end
-        end
-
+  def install_engine
+    generate 'active_encode:install'
+    rake 'active_encode:install:migrations'
+  end
+end

--- a/spec/units/callbacks_spec.rb
+++ b/spec/units/callbacks_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::Callbacks do
@@ -36,14 +37,14 @@ describe ActiveEncode::Callbacks do
   end
 
   describe 'find callback' do
-    let(:encode) { CallbackEncode.create("sample.mp4") }
     subject { CallbackEncode.find(encode.id).history }
+    let(:encode) { CallbackEncode.create("sample.mp4") }
     it { is_expected.to include("CallbackEncode ran after_find") }
   end
 
   describe 'reload callback' do
-    let(:encode) { CallbackEncode.create("sample.mp4") }
     subject { encode.reload.history }
+    let(:encode) { CallbackEncode.create("sample.mp4") }
     it { is_expected.to include("CallbackEncode ran after_reload") }
   end
 

--- a/spec/units/core_spec.rb
+++ b/spec/units/core_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::Core do
@@ -5,7 +6,7 @@ describe ActiveEncode::Core do
     class CustomEncode < ActiveEncode::Base
     end
   end
-   after do
+  after do
     Object.send(:remove_const, :CustomEncode)
   end
 
@@ -24,8 +25,8 @@ describe ActiveEncode::Core do
   end
 
   describe 'find' do
-    let(:id) { encode_class.create(nil).id }
     subject { encode_class.find(id) }
+    let(:id) { encode_class.create(nil).id }
 
     it { is_expected.to be_a encode_class }
     its(:id) { is_expected.to eq id }
@@ -70,8 +71,8 @@ describe ActiveEncode::Core do
   end
 
   describe '#create!' do
-    let(:encode) { encode_class.new(nil) }
     subject { encode.create! }
+    let(:encode) { encode_class.new(nil) }
 
     it { is_expected.to equal encode }
     it { is_expected.to be_a encode_class }
@@ -89,8 +90,8 @@ describe ActiveEncode::Core do
   end
 
   describe '#cancel!' do
-    let(:encode) { encode_class.create(nil) }
     subject { encode.cancel! }
+    let(:encode) { encode_class.create(nil) }
 
     it { is_expected.to equal encode }
     it { is_expected.to be_a encode_class }
@@ -108,8 +109,8 @@ describe ActiveEncode::Core do
   end
 
   describe '#reload' do
-    let(:encode) { encode_class.create(nil) }
     subject { encode.reload }
+    let(:encode) { encode_class.create(nil) }
 
     it { is_expected.to equal encode }
     it { is_expected.to be_a encode_class }
@@ -134,15 +135,15 @@ describe ActiveEncode::Core do
         end
       end
     end
-     after do
+    after do
       Object.send(:remove_const, :DefaultOptionsEncode)
     end
 
+    subject { encode.options }
     let(:encode_class) { DefaultOptionsEncode }
     let(:default_options) { { preset: 'video' } }
-    let(:options) { { output: [{label: 'high', ffmpeg_opt: "640x480" }] } }
+    let(:options) { { output: [{ label: 'high', ffmpeg_opt: "640x480" }] } }
     let(:encode) { encode_class.new(nil, options) }
-    subject { encode.options }
 
     it 'merges default options and options parameter' do
       expect(subject).to include default_options

--- a/spec/units/engine_adapter_spec.rb
+++ b/spec/units/engine_adapter_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::EngineAdapter do

--- a/spec/units/file_locator_spec.rb
+++ b/spec/units/file_locator_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Copyright 2011-2018, The Trustees of Indiana University and Northwestern
 #   University.  Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -24,12 +25,12 @@ describe FileLocator, type: :service do
     let(:key) { "mykey.mp4" }
     let(:s3file) { FileLocator::S3File.new("s3://#{bucket}/#{key}") }
 
-    it "should be able to initialize from an S3 URI" do
+    it "is able to initialize from an S3 URI" do
       expect(s3file.bucket).to eq bucket
       expect(s3file.key).to eq key
     end
 
-    it "should return an S3 Object" do
+    it "returns an S3 Object" do
       s3_object = s3file.object
       expect(s3_object).to be_an Aws::S3::Object
       expect(s3_object.bucket_name).to eq bucket
@@ -42,30 +43,30 @@ describe FileLocator, type: :service do
     let(:source) { "file://#{path}" }
     let(:locator) { FileLocator.new(source) }
 
-    it "should return the correct uri" do
+    it "returns the correct uri" do
       expect(locator.uri).to eq Addressable::URI.parse(source)
     end
 
-    it "should return the correct location" do
+    it "returns the correct location" do
       expect(locator.location).to eq path
     end
 
-    it "should tell if file exists" do
+    it "tells if file exists" do
       allow(File).to receive(:exist?).with(path) { true }
       expect(locator.exist?).to be_truthy
     end
 
     context "return file" do
       let(:file) { double(File) }
-      before :each do
+      before do
         allow(File).to receive(:open).and_return file
       end
 
-      it "should return reader" do
+      it "returns reader" do
         expect(locator.reader).to eq file
       end
 
-      it "should return attachment" do
+      it "returns attachment" do
         expect(locator.attachment).to eq file
       end
     end
@@ -77,23 +78,23 @@ describe FileLocator, type: :service do
     let(:source) { "s3://#{bucket}/#{key}" }
     let(:locator) { FileLocator.new(source) }
 
-    it "should return the correct uri" do
+    it "returns the correct uri" do
       expect(locator.uri).to eq Addressable::URI.parse(source)
     end
 
-    it "should return the correct location" do
+    it "returns the correct location" do
       expect(locator.location).to start_with "https://#{bucket}.s3.us-stubbed-1.amazonaws.com/#{key}"
     end
 
-    it "should tell if file exists" do
+    it "tells if file exists" do
       expect(locator.exist?).to be_truthy
     end
 
-    it "should return reader" do
+    it "returns reader" do
       expect(locator.reader).to be_a StringIO
     end
 
-    it "should return attachment" do
+    it "returns attachment" do
       expect(locator.attachment).to eq Addressable::URI.parse(source)
     end
   end
@@ -103,25 +104,25 @@ describe FileLocator, type: :service do
     let(:source) { "bogus://#{path}" }
     let(:locator) { FileLocator.new(source) }
 
-    it "should return the correct uri" do
+    it "returns the correct uri" do
       expect(locator.uri).to eq Addressable::URI.parse(source)
     end
 
-    it "should return the correct location" do
+    it "returns the correct location" do
       expect(locator.location).to eq source
     end
 
-    it "should tell if file exists" do
+    it "tells if file exists" do
       expect(locator.exist?).to be_falsy
     end
 
-    it "should return reader" do
+    it "returns reader" do
       io = double(IO)
       allow(Kernel).to receive(:open).and_return io
       expect(locator.reader).to eq io
     end
 
-    it "should return attachment" do
+    it "returns attachment" do
       expect(locator.attachment).to eq locator.location
     end
   end

--- a/spec/units/global_id_spec.rb
+++ b/spec/units/global_id_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::GlobalID do
@@ -11,9 +12,9 @@ describe ActiveEncode::GlobalID do
   end
 
   describe '#to_global_id' do
+    subject { encode.to_global_id }
     let(:encode_class) { ActiveEncode::Base }
     let(:encode) { encode_class.create(nil) }
-    subject { encode.to_global_id }
 
     it { is_expected.to be_a GlobalID }
     its(:model_class) { is_expected.to eq encode_class }
@@ -31,17 +32,17 @@ describe ActiveEncode::GlobalID do
   end
 
   describe 'GlobalID::Locator#locate' do
+    subject { GlobalID::Locator.locate(global_id) }
     let(:encode_class) { ActiveEncode::Base }
     let(:encode) { encode_class.create(nil) }
     let(:global_id) { encode.to_global_id }
-    subject { GlobalID::Locator.locate(global_id) }
 
     it { is_expected.to be_a encode_class }
     its(:id) { is_expected.to eq encode.id }
 
     context 'with an ActiveEncode::Base subclass' do
       let(:encode_class) { CustomEncode }
-      
+
       it { is_expected.to be_a encode_class }
       its(:id) { is_expected.to eq encode.id }
     end

--- a/spec/units/input_spec.rb
+++ b/spec/units/input_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::Input do
@@ -6,8 +7,10 @@ describe ActiveEncode::Input do
   describe 'attributes' do
     it { is_expected.to respond_to(:id, :url) }
     it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }
-    it { is_expected.to respond_to(:width, :height, :frame_rate, :checksum,
-                                   :audio_codec, :video_codec, :audio_bitrate, :video_bitrate) }
+    it {
+      is_expected.to respond_to(:width, :height, :frame_rate, :checksum,
+                                :audio_codec, :video_codec, :audio_bitrate, :video_bitrate)
+    }
   end
 
   describe '#valid?' do
@@ -15,8 +18,8 @@ describe ActiveEncode::Input do
       described_class.new.tap do |obj|
         obj.id = "1"
         obj.url = "file:///tmp/video.mp4"
-        obj.created_at = Time.now
-        obj.updated_at = Time.now
+        obj.created_at = Time.now.utc
+        obj.updated_at = Time.now.utc
       end
     end
 
@@ -31,7 +34,7 @@ describe ActiveEncode::Input do
       expect(valid_input.tap { |obj| obj.created_at = "today" }).not_to be_valid
       expect(valid_input.tap { |obj| obj.updated_at = nil }).not_to be_valid
       expect(valid_input.tap { |obj| obj.updated_at = "today" }).not_to be_valid
-      expect(valid_input.tap { |obj| obj.created_at = Time.now }).not_to be_valid
+      expect(valid_input.tap { |obj| obj.created_at = Time.now.utc }).not_to be_valid
     end
   end
 end

--- a/spec/units/output_spec.rb
+++ b/spec/units/output_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::Output do
@@ -6,8 +7,10 @@ describe ActiveEncode::Output do
   describe 'attributes' do
     it { is_expected.to respond_to(:id, :url, :label) }
     it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }
-    it { is_expected.to respond_to(:width, :height, :frame_rate, :checksum,
-                                   :audio_codec, :video_codec, :audio_bitrate, :video_bitrate) }
+    it {
+      is_expected.to respond_to(:width, :height, :frame_rate, :checksum,
+                                :audio_codec, :video_codec, :audio_bitrate, :video_bitrate)
+    }
   end
 
   describe '#valid?' do
@@ -16,8 +19,8 @@ describe ActiveEncode::Output do
         obj.id = "1"
         obj.url = "file:///tmp/video.mp4"
         obj.label = "HD"
-        obj.created_at = Time.now
-        obj.updated_at = Time.now
+        obj.created_at = Time.now.utc
+        obj.updated_at = Time.now.utc
       end
     end
 
@@ -33,7 +36,7 @@ describe ActiveEncode::Output do
       expect(valid_output.tap { |obj| obj.created_at = "today" }).not_to be_valid
       expect(valid_output.tap { |obj| obj.updated_at = nil }).not_to be_valid
       expect(valid_output.tap { |obj| obj.updated_at = "today" }).not_to be_valid
-      expect(valid_output.tap { |obj| obj.created_at = Time.now }).not_to be_valid
+      expect(valid_output.tap { |obj| obj.created_at = Time.now.utc }).not_to be_valid
     end
   end
 end

--- a/spec/units/persistence_spec.rb
+++ b/spec/units/persistence_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe ActiveEncode::Persistence, db_clean: true do
@@ -12,8 +13,8 @@ describe ActiveEncode::Persistence, db_clean: true do
   end
 
   describe 'find' do
-    let(:encode) { CustomEncode.create(nil) }
     subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+    let(:encode) { CustomEncode.create(nil) }
 
     it 'persists changes on find' do
       expect { CustomEncode.find(encode.id) }.to change { subject.reload.updated_at }
@@ -21,9 +22,9 @@ describe ActiveEncode::Persistence, db_clean: true do
   end
 
   describe 'create' do
+    subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
     let(:create_options) { { option: 'value' } }
     let(:encode) { CustomEncode.create(nil, create_options) }
-    subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
 
     it 'creates a record' do
       expect { encode }.to change { ActiveEncode::EncodeRecord.count }.by(1)
@@ -40,8 +41,8 @@ describe ActiveEncode::Persistence, db_clean: true do
   end
 
   describe 'cancel' do
-    let(:encode) { CustomEncode.create(nil) }
     subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+    let(:encode) { CustomEncode.create(nil) }
 
     it 'persists changes on cancel' do
       expect { encode.cancel! }.to change { subject.reload.state }.from("running").to("cancelled")
@@ -49,8 +50,8 @@ describe ActiveEncode::Persistence, db_clean: true do
   end
 
   describe 'reload' do
-    let(:encode) { CustomEncode.create(nil) }
     subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
+    let(:encode) { CustomEncode.create(nil) }
 
     it 'persists changes on reload' do
       expect { encode.reload }.to change { subject.reload.updated_at }

--- a/spec/units/persistence_spec.rb
+++ b/spec/units/persistence_spec.rb
@@ -21,7 +21,8 @@ describe ActiveEncode::Persistence, db_clean: true do
   end
 
   describe 'create' do
-    let(:encode) { CustomEncode.create(nil) }
+    let(:create_options) { { option: 'value' } }
+    let(:encode) { CustomEncode.create(nil, create_options) }
     subject { ActiveEncode::EncodeRecord.find_by(global_id: encode.to_global_id.to_s) }
 
     it 'creates a record' do
@@ -35,6 +36,7 @@ describe ActiveEncode::Persistence, db_clean: true do
     its(:raw_object) { is_expected.to eq encode.to_json }
     its(:created_at) { is_expected.to be_within(1.second).of encode.created_at }
     its(:updated_at) { is_expected.to be_within(1.second).of encode.updated_at }
+    its(:create_options) { is_expected.to eq create_options.to_json }
   end
 
   describe 'cancel' do

--- a/spec/units/polling_job_spec.rb
+++ b/spec/units/polling_job_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe ActiveEncode::PollingJob do
@@ -22,9 +23,9 @@ describe ActiveEncode::PollingJob do
   end
 
   describe '#perform' do
-    let(:encode) { PollingEncode.create("sample.mp4").tap { |encode| encode.state = state } }
-    let(:poll) { ActiveEncode::PollingJob.new }
     subject { encode.history }
+    let(:encode) { PollingEncode.create("sample.mp4").tap { |encode| encode.state = state } }
+    let(:poll) { described_class.new }
 
     before do
       encode
@@ -41,7 +42,7 @@ describe ActiveEncode::PollingJob do
       end
 
       it "does not re-enqueue itself" do
-        expect(ActiveEncode::PollingJob).not_to have_been_enqueued
+        expect(described_class).not_to have_been_enqueued
       end
     end
 
@@ -54,7 +55,7 @@ describe ActiveEncode::PollingJob do
       end
 
       it "does not re-enqueue itself" do
-        expect(ActiveEncode::PollingJob).not_to have_been_enqueued
+        expect(described_class).not_to have_been_enqueued
       end
     end
 
@@ -67,7 +68,7 @@ describe ActiveEncode::PollingJob do
       end
 
       it "does not re-enqueue itself" do
-        expect(ActiveEncode::PollingJob).not_to have_been_enqueued
+        expect(described_class).not_to have_been_enqueued
       end
     end
 
@@ -79,7 +80,7 @@ describe ActiveEncode::PollingJob do
       end
 
       it "re-enqueues itself" do
-        expect(ActiveEncode::PollingJob).to have_been_enqueued.with(encode)
+        expect(described_class).to have_been_enqueued.with(encode)
       end
     end
   end

--- a/spec/units/polling_spec.rb
+++ b/spec/units/polling_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe ActiveEncode::Polling do

--- a/spec/units/status_spec.rb
+++ b/spec/units/status_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ActiveEncode::Status do
@@ -5,13 +6,12 @@ describe ActiveEncode::Status do
     class CustomEncode < ActiveEncode::Base
     end
   end
-   after do
+  after do
     Object.send(:remove_const, :CustomEncode)
   end
 
-  let(:encode_class) { ActiveEncode::Base }
-
   subject { encode_class.new(nil) }
+  let(:encode_class) { ActiveEncode::Base }
 
   describe 'attributes' do
     it { is_expected.to respond_to(:state, :errors, :created_at, :updated_at) }


### PR DESCRIPTION
With this we're able to pass in the ID of the Hyrax file set that is associated with this encode job and retrieve it later since it wouldn't normally be available from a normal `ActiveEncode::Base`.