### PR TITLE
Handle case when FFmpeg encode isn't running and cancel is called.

### DIFF
--- a/lib/active_encode/base.rb
+++ b/lib/active_encode/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'active_encode/core'
 require 'active_encode/engine_adapter'
+require 'active_encode/errors'
 require 'active_encode/status'
 require 'active_encode/technical_metadata'
 require 'active_encode/input'
@@ -18,6 +19,4 @@ module ActiveEncode #:nodoc:
     include Callbacks
     include GlobalID
   end
-
-  class NotFound < RuntimeError; end
 end

--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -98,10 +98,17 @@ module ActiveEncode
 
       # Cancel ongoing encode using pid file
       def cancel(id)
-        pid = get_pid(id)
-        Process.kill 'SIGTERM', pid.to_i
-
-        find id
+        encode = find id
+        if encode.running?
+          pid = get_pid(id)
+          Process.kill 'SIGTERM', pid.to_i
+          encode = find id
+        end
+        encode
+      rescue Errno::ESRCH
+        raise NotRunningError
+      rescue StandardError
+        raise CancelError
       end
 
     private

--- a/lib/active_encode/errors.rb
+++ b/lib/active_encode/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module ActiveEncode #:nodoc:
+  class NotFound < RuntimeError; end
+  class NotRunningError < RuntimeError; end
+  class CancelError < RuntimeError; end
+end

--- a/spec/integration/ffmpeg_adapter_spec.rb
+++ b/spec/integration/ffmpeg_adapter_spec.rb
@@ -124,5 +124,20 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
       expect(Process).to receive(:kill).with('SIGTERM', running_job.input.id.to_i)
       running_job.cancel!
     end
+
+    it "does not attempt to stop a non-running encode" do
+      expect(Process).not_to receive(:kill).with('SIGTERM', completed_job.input.id.to_i)
+      completed_job.cancel!
+    end
+
+    it "raises an error if the process can not be found" do
+      expect(Process).to receive(:kill).with('SIGTERM', running_job.input.id.to_i).and_raise(Errno::ESRCH)
+      expect { running_job.cancel! }.to raise_error(ActiveEncode::NotRunningError)
+    end
+
+    it "raises an error" do
+      expect(Process).to receive(:kill).with('SIGTERM', running_job.input.id.to_i).and_raise(Errno::EPERM)
+      expect { running_job.cancel! }.to raise_error(ActiveEncode::CancelError)
+    end
   end
 end


### PR DESCRIPTION
If the program calling ActiveEncode doesn't notice that the encode status isn't running and tries calling cancel then kill raises an error `No such process`.   This PR skips calling cancel when the encode isn't actually running and wraps that error and others in custom errors.
We might want this to raise the `NotRunningError` when the encode isn't running when called but that might lead to a race condition.