### PR TITLE
Rescue errors so they can be recorded on the returned encode object

### DIFF
--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -53,10 +53,16 @@ module ActiveEncode
         File.open(working_path("pid", new_encode.id), 'w') { |file| file.write pid }
         new_encode.input.id = pid
 
-        # Prevent zombie process
-        Process.detach(pid)
-
         new_encode
+      rescue StandardError => e
+        new_encode.state = :failed
+        new_encode.percent_complete = 1
+        new_encode.errors = [e.message]
+        write_errors new_encode
+        return new_encode
+      ensure
+        # Prevent zombie process
+        Process.detach(pid) if pid.present?
       end
 
       # Return encode object from file system

--- a/spec/integration/ffmpeg_adapter_spec.rb
+++ b/spec/integration/ffmpeg_adapter_spec.rb
@@ -143,6 +143,17 @@ describe ActiveEncode::EngineAdapters::FfmpegAdapter do
         end
       end
     end
+
+    context 'when failed' do
+      subject { created_job }
+
+      before do
+        allow_any_instance_of(Object).to receive(:`).and_raise Errno::ENOENT
+      end
+
+      it { is_expected.to be_failed }
+      its(:errors) { is_expected.not_to be_empty }
+    end
   end
 
   describe "#find" do


### PR DESCRIPTION
Fixes avalonmediasystem/avalon#3671