### PR TITLE
Show job as still running within 10 minutes if completed details aren't yet available

### DIFF
--- a/spec/fixtures/media_convert/job_completed_empty_detail.json
+++ b/spec/fixtures/media_convert/job_completed_empty_detail.json
@@ -1,0 +1,1 @@
+{"results":[],"statistics":{"records_matched":1.0,"records_scanned":13.0,"bytes_scanned":10750.0},"status":"Complete"}


### PR DESCRIPTION
When using the AWS MediaConvert adapter, there can be a brief delay between the job showing as `COMPLETE` and the result message with the encoding details being available in CloudWatch Logs. In v0.8.0, this condition would result in an `ActiveEncode::NotFound` exception, which is not the right way to handle it.

This PR sets the state back to `:running` if MediaConvert reports the job as `COMPLETE` with a finish time within the last 10 minutes but CloudWatch hasn't received the message yet. If the job's `finish_time` is more than 10 minutes ago, it will raise an adapter-specific `ResultsNotAvailable` exception with the completed `encode` object attached.
