### PR TITLE
Retry MediaConvert operations using retriable

### DIFF
--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails"
+  spec.add_dependency "retriable"
 
   spec.add_development_dependency "aws-sdk-cloudwatchevents"
   spec.add_development_dependency "aws-sdk-cloudwatchlogs"

--- a/spec/integration/media_convert_adapter_spec.rb
+++ b/spec/integration/media_convert_adapter_spec.rb
@@ -176,4 +176,27 @@ describe ActiveEncode::EngineAdapters::MediaConvertAdapter do
       end
     end
   end
+
+  describe "retry" do
+    it "recovers from Aws::MediaConvert errors" do
+      mediaconvert.stub_responses(:get_job, [
+        Aws::MediaConvert::Errors::TooManyRequestsException.new(nil, 'Too Many Requests'),
+        reconstitute_response("media_convert/job_progressing.json")
+      ])
+      expect(ActiveEncode::Base.find(job_id)).to eq(running_job)
+    end
+
+    it "raises when the retries run out" do
+      mediaconvert.stub_responses(:get_job, [
+        Aws::MediaConvert::Errors::TooManyRequestsException.new(nil, 'Too Many Requests 1'),
+        Aws::MediaConvert::Errors::TooManyRequestsException.new(nil, 'Too Many Requests 2'),
+        Aws::MediaConvert::Errors::TooManyRequestsException.new(nil, 'Too Many Requests 3'),
+        reconstitute_response("media_convert/job_progressing.json")
+      ])
+      expect { ActiveEncode::Base.find(job_id) }.to raise_error do |error|
+        expect(error).to be_a(Aws::MediaConvert::Errors::TooManyRequestsException)
+        expect(error.message).to eq('Too Many Requests 3')
+      end
+    end
+  end
 end


### PR DESCRIPTION
AWS MediaConvert has rate limits that are easy to run up against when using ActiveEncode. These are mostly harmless – they just raise `Aws::MediaConvert::Errors::TooManyRequestsException` and the job goes back in the queue. This PR uses the `retriable` gem (already in use within the Avalon/Hyrax/Samvera ecosystem as a second-tier dependency) to retry MediaConvert requests three times with exponential backoff and random jitter.