### PR TITLE
MediaConvert adapter setup! improvements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,9 @@ AllCops:
     - 'vendor/**/*'
   Include:
     - '**/Rakefile'
+
+Layout/IndentHash:
+  Enabled: false
+
+Style/BracesAroundHashParameters:
+  Enabled: false

--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -51,6 +51,8 @@ module ActiveEncode
         cmaf: { fragment_length: 2, segment_control: "SEGMENTED_FILES", segment_length: 10 }
       }.freeze
 
+      SETUP_LOG_GROUP_RETENTION_DAYS = 3
+
       class ResultsNotAvailable < RuntimeError
         attr_reader :encode
 
@@ -351,6 +353,11 @@ module ActiveEncode
           return result unless result.nil?
 
           cloudwatch_logs.create_log_group(log_group_name: name)
+          cloudwatch_logs.put_retention_policy({
+            log_group_name: name,
+            retention_in_days: SETUP_LOG_GROUP_RETENTION_DAYS
+          })
+
           find_log_group(name)
         end
 

--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -75,7 +75,8 @@ module ActiveEncode
           source: ["aws.mediaconvert"],
           "detail-type": ["MediaConvert Job State Change"],
           detail: {
-            queue: [queue_arn]
+            queue: [queue_arn],
+            status: ["COMPLETE"]
           }
         }
 
@@ -87,7 +88,7 @@ module ActiveEncode
           name: rule_name,
           event_pattern: event_pattern.to_json,
           state: "ENABLED",
-          description: "Forward MediaConvert job state changes from queue #{queue} to #{log_group}"
+          description: "Forward MediaConvert job state changes on COMPLETE from queue #{queue} to #{log_group}"
         )
 
         cloudwatch_events.put_targets(

--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -354,10 +354,10 @@ module ActiveEncode
           return result unless result.nil?
 
           cloudwatch_logs.create_log_group(log_group_name: name)
-          cloudwatch_logs.put_retention_policy({
+          cloudwatch_logs.put_retention_policy(
             log_group_name: name,
             retention_in_days: SETUP_LOG_GROUP_RETENTION_DAYS
-          })
+          )
 
           find_log_group(name)
         end

--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -77,7 +77,9 @@ module ActiveEncode
           }
         }
 
-        log_group_arn = create_log_group(log_group).arn
+        # AWS is inconsistent about whether a cloudwatch ARN has :* appended
+        # to the end, and we need to make sure it doesn't in the rule target.
+        log_group_arn = create_log_group(log_group).arn.chomp(":*")
 
         cloudwatch_events.put_rule(
           name: rule_name,


### PR DESCRIPTION
Improvements to the setup! method that is meant to set up a cloudwatch rule and log group suitable for the adapter to fetch output information from on complete. 

One change was necessary for setup! to create a working setup:

- Fix cloudwatch rule target ARN

Two changes that are improvements:

- when setup! creates a cloudwatch log group, create a retention policy for it too please
- setup! creates a cloudwatch rule that only forwards COMPLETE events, as that's all this func care about

There are no existing automated tests for setup!, and I couldn't see a reasonable way to create any at this point. But I did test this manually, and the adapter is now/still succesfully finding the log event for output info on completion. 
