### PR TITLE
Update bixby to latest, with rubocop to more recent

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,8 +13,5 @@ AllCops:
   Include:
     - '**/Rakefile'
 
-Layout/IndentHash:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
+Rails/RakeEnvironment:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_from: .rubocop_todo.yml
 
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
   Exclude:
     - 'active_encode.gemspec'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,8 +10,6 @@ AllCops:
   Exclude:
     - 'active_encode.gemspec'
     - 'vendor/**/*'
-  Include:
-    - '**/Rakefile'
 
 Rails/RakeEnvironment:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/CyclomaticComplexity:
     - 'lib/active_encode/engine_adapters/ffmpeg_adapter.rb'
     - 'lib/active_encode/engine_adapters/zencoder_adapter.rb'
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     - 'lib/active_encode/engine_adapters/matterhorn_adapter.rb'
     - 'spec/**/*'

--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "aws-sdk-elastictranscoder"
   spec.add_development_dependency "aws-sdk-mediaconvert"
   spec.add_development_dependency "aws-sdk-s3"
-  spec.add_development_dependency "bixby", '~> 1.0.0'
+  spec.add_development_dependency "bixby", '~> 3.0'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "database_cleaner"

--- a/app/controllers/active_encode/encode_record_controller.rb
+++ b/app/controllers/active_encode/encode_record_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module ActiveEncode
-  class EncodeRecordController < ActionController::Base
+  class EncodeRecordController < ApplicationController
     rescue_from ActiveRecord::RecordNotFound do |e|
       render json: { message: e.message }, status: :not_found
     end

--- a/app/jobs/active_encode/polling_job.rb
+++ b/app/jobs/active_encode/polling_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module ActiveEncode
-  class PollingJob < ActiveJob::Base
+  class PollingJob < ApplicationJob
     def perform(encode)
       encode.run_callbacks(:status_update) { encode }
       case encode.state

--- a/app/models/active_encode/encode_record.rb
+++ b/app/models/active_encode/encode_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module ActiveEncode
-  class EncodeRecord < ActiveRecord::Base
+  class EncodeRecord < ApplicationRecord
     # sql id, globalid, state, adapter, input filename/job title, timestamps
   end
 end

--- a/lib/active_encode/core.rb
+++ b/lib/active_encode/core.rb
@@ -73,19 +73,19 @@ module ActiveEncode
 
     protected
 
-      def merge!(encode)
-        @id = encode.id
-        @input = encode.input
-        @output = encode.output
-        @options = encode.options
-        @state = encode.state
-        @errors = encode.errors
-        @created_at = encode.created_at
-        @updated_at = encode.updated_at
-        @current_operations = encode.current_operations
-        @percent_complete = encode.percent_complete
+    def merge!(encode)
+      @id = encode.id
+      @input = encode.input
+      @output = encode.output
+      @options = encode.options
+      @state = encode.state
+      @errors = encode.errors
+      @created_at = encode.created_at
+      @updated_at = encode.updated_at
+      @current_operations = encode.current_operations
+      @percent_complete = encode.percent_complete
 
-        self
-      end
+      self
+    end
   end
 end

--- a/lib/active_encode/engine_adapter.rb
+++ b/lib/active_encode/engine_adapter.rb
@@ -29,21 +29,21 @@ module ActiveEncode
 
       private
 
-        def interpret_adapter(name_or_adapter_or_class)
-          case name_or_adapter_or_class
-          when Symbol, String
-            ActiveEncode::EngineAdapters.lookup(name_or_adapter_or_class).new
-          else
-            name_or_adapter_or_class if engine_adapter?(name_or_adapter_or_class)
-            raise ArgumentError unless engine_adapter?(name_or_adapter_or_class)
-          end
+      def interpret_adapter(name_or_adapter_or_class)
+        case name_or_adapter_or_class
+        when Symbol, String
+          ActiveEncode::EngineAdapters.lookup(name_or_adapter_or_class).new
+        else
+          name_or_adapter_or_class if engine_adapter?(name_or_adapter_or_class)
+          raise ArgumentError unless engine_adapter?(name_or_adapter_or_class)
         end
+      end
 
-        ENGINE_ADAPTER_METHODS = %i[create find cancel].freeze
+      ENGINE_ADAPTER_METHODS = %i[create find cancel].freeze
 
-        def engine_adapter?(object)
-          ENGINE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }
-        end
+      def engine_adapter?(object)
+        ENGINE_ADAPTER_METHODS.all? { |meth| object.respond_to?(meth) }
+      end
     end
   end
 end

--- a/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb
@@ -41,194 +41,194 @@ module ActiveEncode
 
       private
 
-        # Needs region and credentials setup per http://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticTranscoder/Client.html
-        def client
-          @client ||= Aws::ElasticTranscoder::Client.new
+      # Needs region and credentials setup per http://docs.aws.amazon.com/sdkforruby/api/Aws/ElasticTranscoder/Client.html
+      def client
+        @client ||= Aws::ElasticTranscoder::Client.new
+      end
+
+      def s3client
+        Aws::S3::Client.new
+      end
+
+      def get_job_details(job_id)
+        client.read_job(id: job_id)&.job
+      end
+
+      def build_encode(job)
+        return nil if job.nil?
+        encode = ActiveEncode::Base.new(convert_input(job), {})
+        encode.id = job.id
+        encode.state = JOB_STATES[job.status]
+        encode.current_operations = []
+        encode.percent_complete = convert_percent_complete(job)
+        encode.created_at = convert_time(job.timing["submit_time_millis"])
+        encode.updated_at = convert_time(job.timing["finish_time_millis"]) || convert_time(job.timing["start_time_millis"]) || encode.created_at
+
+        encode.output = convert_output(job)
+        encode.errors = job.outputs.select { |o| o.status == "Error" }.collect(&:status_detail).compact
+
+        tech_md = convert_tech_metadata(job.input.detected_properties)
+        [:width, :height, :frame_rate, :duration, :file_size].each do |field|
+          encode.input.send("#{field}=", tech_md[field])
         end
 
-        def s3client
-          Aws::S3::Client.new
+        encode.input.id = job.id
+        encode.input.state = encode.state
+        encode.input.created_at = encode.created_at
+        encode.input.updated_at = encode.updated_at
+
+        encode
+      end
+
+      def convert_time(time_millis)
+        return nil if time_millis.nil?
+        Time.at(time_millis / 1000).utc
+      end
+
+      def convert_bitrate(rate)
+        return nil if rate.nil?
+        (rate.to_f * 1024).to_s
+      end
+
+      def convert_state(job)
+        case job.status
+        when "Submitted", "Progressing" # Should there be a queued state?
+          :running
+        when "Canceled"
+          :cancelled
+        when "Error"
+          :failed
+        when "Complete"
+          :completed
         end
+      end
 
-        def get_job_details(job_id)
-          client.read_job(id: job_id)&.job
+      def convert_percent_complete(job)
+        job.outputs.inject(0) { |sum, output| sum + output_percentage(output) } / job.outputs.length
+      end
+
+      def output_percentage(output)
+        case output.status
+        when "Submitted"
+          10
+        when "Progressing", "Canceled", "Error"
+          50
+        when "Complete"
+          100
+        else
+          0
         end
+      end
 
-        def build_encode(job)
-          return nil if job.nil?
-          encode = ActiveEncode::Base.new(convert_input(job), {})
-          encode.id = job.id
-          encode.state = JOB_STATES[job.status]
-          encode.current_operations = []
-          encode.percent_complete = convert_percent_complete(job)
-          encode.created_at = convert_time(job.timing["submit_time_millis"])
-          encode.updated_at = convert_time(job.timing["finish_time_millis"]) || convert_time(job.timing["start_time_millis"]) || encode.created_at
+      def convert_input(job)
+        job.input.key
+      end
 
-          encode.output = convert_output(job)
-          encode.errors = job.outputs.select { |o| o.status == "Error" }.collect(&:status_detail).compact
-
-          tech_md = convert_tech_metadata(job.input.detected_properties)
-          [:width, :height, :frame_rate, :duration, :file_size].each do |field|
-            encode.input.send("#{field}=", tech_md[field])
-          end
-
-          encode.input.id = job.id
-          encode.input.state = encode.state
-          encode.input.created_at = encode.created_at
-          encode.input.updated_at = encode.updated_at
-
-          encode
+      def copy_to_input_bucket(input_url, bucket)
+        case Addressable::URI.parse(input_url).scheme
+        when nil, 'file'
+          upload_to_s3 input_url, bucket
+        when 's3'
+          check_s3_bucket input_url, bucket
         end
+      end
 
-        def convert_time(time_millis)
-          return nil if time_millis.nil?
-          Time.at(time_millis / 1000).utc
-        end
-
-        def convert_bitrate(rate)
-          return nil if rate.nil?
-          (rate.to_f * 1024).to_s
-        end
-
-        def convert_state(job)
-          case job.status
-          when "Submitted", "Progressing" # Should there be a queued state?
-            :running
-          when "Canceled"
-            :cancelled
-          when "Error"
-            :failed
-          when "Complete"
-            :completed
-          end
-        end
-
-        def convert_percent_complete(job)
-          job.outputs.inject(0) { |sum, output| sum + output_percentage(output) } / job.outputs.length
-        end
-
-        def output_percentage(output)
-          case output.status
-          when "Submitted"
-            10
-          when "Progressing", "Canceled", "Error"
-            50
-          when "Complete"
-            100
-          else
-            0
-          end
-        end
-
-        def convert_input(job)
-          job.input.key
-        end
-
-        def copy_to_input_bucket(input_url, bucket)
-          case Addressable::URI.parse(input_url).scheme
-          when nil, 'file'
-            upload_to_s3 input_url, bucket
-          when 's3'
-            check_s3_bucket input_url, bucket
-          end
-        end
-
-        def check_s3_bucket(input_url, source_bucket)
-          # logger.info("Checking `#{input_url}'")
-          s3_object = FileLocator::S3File.new(input_url).object
-          if s3_object.bucket_name == source_bucket
-            # logger.info("Already in bucket `#{source_bucket}'")
-            s3_object.key
-          else
-            s3_key = File.join(SecureRandom.uuid, s3_object.key)
-            # logger.info("Copying to `#{source_bucket}/#{input_url}'")
-            target = Aws::S3::Object.new(bucket_name: source_bucket, key: input_url)
-            target.copy_from(s3_object, multipart_copy: s3_object.size > 15_728_640) # 15.megabytes
-            s3_key
-          end
-        end
-
-        def upload_to_s3(input_url, source_bucket)
-          # original_input = input_url
-          bucket = Aws::S3::Resource.new(client: s3client).bucket(source_bucket)
-          filename = FileLocator.new(input_url).location
-          s3_key = File.join(SecureRandom.uuid, File.basename(filename))
-          # logger.info("Copying `#{original_input}' to `#{source_bucket}/#{input_url}'")
-          obj = bucket.object(s3_key)
-          obj.upload_file filename
-
+      def check_s3_bucket(input_url, source_bucket)
+        # logger.info("Checking `#{input_url}'")
+        s3_object = FileLocator::S3File.new(input_url).object
+        if s3_object.bucket_name == source_bucket
+          # logger.info("Already in bucket `#{source_bucket}'")
+          s3_object.key
+        else
+          s3_key = File.join(SecureRandom.uuid, s3_object.key)
+          # logger.info("Copying to `#{source_bucket}/#{input_url}'")
+          target = Aws::S3::Object.new(bucket_name: source_bucket, key: input_url)
+          target.copy_from(s3_object, multipart_copy: s3_object.size > 15_728_640) # 15.megabytes
           s3_key
         end
+      end
 
-        def read_preset(id)
-          @presets ||= {}
-          @presets[id] ||= client.read_preset(id: id).preset
-        end
+      def upload_to_s3(input_url, source_bucket)
+        # original_input = input_url
+        bucket = Aws::S3::Resource.new(client: s3client).bucket(source_bucket)
+        filename = FileLocator.new(input_url).location
+        s3_key = File.join(SecureRandom.uuid, File.basename(filename))
+        # logger.info("Copying `#{original_input}' to `#{source_bucket}/#{input_url}'")
+        obj = bucket.object(s3_key)
+        obj.upload_file filename
 
-        def convert_output(job)
-          @pipeline ||= client.read_pipeline(id: job.pipeline_id).pipeline
-          job.outputs.collect do |joutput|
-            preset = read_preset(joutput.preset_id)
-            extension = preset.container == 'ts' ? '.m3u8' : ''
-            additional_metadata = {
-              managed: false,
-              id: joutput.id,
-              label: joutput.key.split("/", 2).first,
-              url: "s3://#{@pipeline.output_bucket}/#{job.output_key_prefix}#{joutput.key}#{extension}"
-            }
-            tech_md = convert_tech_metadata(joutput, preset).merge(additional_metadata)
+        s3_key
+      end
 
-            output = ActiveEncode::Output.new
-            output.state = convert_state(joutput)
-            output.created_at = convert_time(job.timing["submit_time_millis"])
-            output.updated_at = convert_time(job.timing["finish_time_millis"] || job.timing["start_time_millis"]) || output.created_at
+      def read_preset(id)
+        @presets ||= {}
+        @presets[id] ||= client.read_preset(id: id).preset
+      end
 
-            [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
-             :audio_bitrate, :video_bitrate, :file_size, :label, :url, :id].each do |field|
-              output.send("#{field}=", tech_md[field])
-            end
-
-            output
-          end
-        end
-
-        def convert_errors(job)
-          job.outputs.select { |o| o.status == "Error" }.collect(&:status_detail).compact
-        end
-
-        def convert_tech_metadata(props, preset = nil)
-          return {} if props.nil? || props.empty?
-          metadata_fields = {
-            file_size: { key: :file_size, method: :itself },
-            duration_millis: { key: :duration, method: :to_i },
-            frame_rate: { key: :frame_rate, method: :to_i },
-            segment_duration: { key: :segment_duration, method: :itself },
-            width: { key: :width, method: :itself },
-            height: { key: :height, method: :itself }
+      def convert_output(job)
+        @pipeline ||= client.read_pipeline(id: job.pipeline_id).pipeline
+        job.outputs.collect do |joutput|
+          preset = read_preset(joutput.preset_id)
+          extension = preset.container == 'ts' ? '.m3u8' : ''
+          additional_metadata = {
+            managed: false,
+            id: joutput.id,
+            label: joutput.key.split("/", 2).first,
+            url: "s3://#{@pipeline.output_bucket}/#{job.output_key_prefix}#{joutput.key}#{extension}"
           }
+          tech_md = convert_tech_metadata(joutput, preset).merge(additional_metadata)
 
-          metadata = {}
-          props.each_pair do |key, value|
-            next if value.nil?
-            conversion = metadata_fields[key.to_sym]
-            next if conversion.nil?
-            metadata[conversion[:key]] = value.send(conversion[:method])
+          output = ActiveEncode::Output.new
+          output.state = convert_state(joutput)
+          output.created_at = convert_time(job.timing["submit_time_millis"])
+          output.updated_at = convert_time(job.timing["finish_time_millis"] || job.timing["start_time_millis"]) || output.created_at
+
+          [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
+           :audio_bitrate, :video_bitrate, :file_size, :label, :url, :id].each do |field|
+            output.send("#{field}=", tech_md[field])
           end
 
-          unless preset.nil?
-            audio = preset.audio
-            video = preset.video
-            metadata.merge!(
-              audio_codec: audio&.codec,
-              audio_channels: audio&.channels,
-              audio_bitrate: convert_bitrate(audio&.bit_rate),
-              video_codec: video&.codec,
-              video_bitrate: convert_bitrate(video&.bit_rate)
-            )
-          end
-
-          metadata
+          output
         end
+      end
+
+      def convert_errors(job)
+        job.outputs.select { |o| o.status == "Error" }.collect(&:status_detail).compact
+      end
+
+      def convert_tech_metadata(props, preset = nil)
+        return {} if props.blank?
+        metadata_fields = {
+          file_size: { key: :file_size, method: :itself },
+          duration_millis: { key: :duration, method: :to_i },
+          frame_rate: { key: :frame_rate, method: :to_i },
+          segment_duration: { key: :segment_duration, method: :itself },
+          width: { key: :width, method: :itself },
+          height: { key: :height, method: :itself }
+        }
+
+        metadata = {}
+        props.each_pair do |key, value|
+          next if value.nil?
+          conversion = metadata_fields[key.to_sym]
+          next if conversion.nil?
+          metadata[conversion[:key]] = value.send(conversion[:method])
+        end
+
+        unless preset.nil?
+          audio = preset.audio
+          video = preset.video
+          metadata.merge!(
+            audio_codec: audio&.codec,
+            audio_channels: audio&.channels,
+            audio_bitrate: convert_bitrate(audio&.bit_rate),
+            video_codec: video&.codec,
+            video_bitrate: convert_bitrate(video&.bit_rate)
+          )
+        end
+
+        metadata
+      end
     end
   end
 end

--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -73,7 +73,7 @@ module ActiveEncode
         new_encode.percent_complete = 1
         new_encode.errors = [e.full_message]
         write_errors new_encode
-        return new_encode
+        new_encode
       ensure
         # Prevent zombie process
         Process.detach(pid) if pid.present?

--- a/lib/active_encode/engine_adapters/matterhorn_adapter.rb
+++ b/lib/active_encode/engine_adapters/matterhorn_adapter.rb
@@ -23,238 +23,240 @@ module ActiveEncode
 
       private
 
-        def fetch_workflow(id)
-          workflow_om = begin
-            Rubyhorn.client.instance_xml(id)
-          rescue Rubyhorn::RestClient::Exceptions::HTTPNotFound
-            nil
+      def fetch_workflow(id)
+        workflow_om = begin
+          Rubyhorn.client.instance_xml(id)
+                      rescue Rubyhorn::RestClient::Exceptions::HTTPNotFound
+                        nil
+        end
+
+        workflow_om ||= begin
+          Rubyhorn.client.get_stopped_workflow(id)
+                        rescue
+                          nil
+        end
+
+        get_workflow(workflow_om)
+      end
+
+      def get_workflow(workflow_om)
+        return nil if workflow_om.nil?
+        if workflow_om.ng_xml.is_a? Nokogiri::XML::Document
+          workflow_om.ng_xml.remove_namespaces!.root
+        else
+          workflow_om.ng_xml
+        end
+      end
+
+      def build_encode(workflow)
+        return nil if workflow.nil?
+        input_url = convert_input(workflow)
+        input_url = get_workflow_title(workflow) if input_url.blank?
+        encode = ActiveEncode::Base.new(input_url, convert_options(workflow))
+        encode.id = convert_id(workflow)
+        encode.state = convert_state(workflow)
+        encode.current_operations = convert_current_operations(workflow)
+        encode.percent_complete = calculate_percent_complete(workflow)
+        encode.created_at = convert_created_at(workflow)
+        encode.updated_at = convert_updated_at(workflow) || encode.created_at
+        encode.output = convert_output(workflow, encode.options)
+        encode.errors = convert_errors(workflow)
+
+        encode.input.id = "presenter/source"
+        encode.input.state = encode.state
+        encode.input.created_at = encode.created_at
+        encode.input.updated_at = encode.updated_at
+        tech_md = convert_tech_metadata(workflow)
+        [:width, :height, :duration, :frame_rate, :checksum, :audio_codec, :video_codec,
+         :audio_bitrate, :video_bitrate].each do |field|
+          encode.input.send("#{field}=", tech_md[field])
+        end
+
+        encode
+      end
+
+      def convert_id(workflow)
+        workflow.attribute('id').to_s
+      end
+
+      def get_workflow_state(workflow)
+        workflow.attribute('state').to_s
+      end
+
+      def convert_state(workflow)
+        case get_workflow_state(workflow)
+        when "INSTANTIATED", "RUNNING" # Should there be a queued state?
+          :running
+        when "STOPPED"
+          :cancelled
+        when "FAILED"
+          workflow.xpath('//operation[@state="FAILED"]').empty? ? :cancelled : :failed
+        when "SUCCEEDED", "SKIPPED" # Should there be a errored state?
+          :completed
+        end
+      end
+
+      def convert_input(workflow)
+        # Need to do anything else since this is a MH url? and this disappears when a workflow is cleaned up
+        workflow.xpath('mediapackage/media/track[@type="presenter/source"]/url/text()').to_s.strip
+      end
+
+      def get_workflow_title(workflow)
+        workflow.xpath('mediapackage/title/text()').to_s.strip
+      end
+
+      def convert_tech_metadata(workflow)
+        convert_track_metadata(workflow.xpath('//track[@type="presenter/source"]').first)
+      end
+
+      def convert_output(workflow, options)
+        outputs = []
+        workflow.xpath('//track[@type="presenter/delivery" and tags/tag[text()="streaming"]]').each do |track|
+          output = ActiveEncode::Output.new
+          output.label = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
+          output.url = track.at("url/text()").to_s
+          if output.url.start_with? "rtmp"
+            output.url = File.join(options[:stream_base], MatterhornRtmpUrl.parse(output.url).to_path) if options[:stream_base]
+          end
+          output.id = track.at("@id").to_s
+
+          tech_md = convert_track_metadata(track)
+          [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
+           :audio_bitrate, :video_bitrate, :file_size].each do |field|
+            output.send("#{field}=", tech_md[field])
           end
 
-          workflow_om ||= begin
-            Rubyhorn.client.get_stopped_workflow(id)
-          rescue
-            nil
-          end
+          output.state = :completed
+          output.created_at = convert_output_created_at(track, workflow)
+          output.updated_at = convert_output_updated_at(track, workflow)
 
-          get_workflow(workflow_om)
+          outputs << output
         end
+        outputs
+      end
 
-        def get_workflow(workflow_om)
-          return nil if workflow_om.nil?
-          if workflow_om.ng_xml.is_a? Nokogiri::XML::Document
-            workflow_om.ng_xml.remove_namespaces!.root
-          else
-            workflow_om.ng_xml
-          end
+      def convert_current_operations(workflow)
+        current_op = workflow.xpath('//operation[@state!="INSTANTIATED"]/@description').last.to_s
+        current_op.present? ? [current_op] : []
+      end
+
+      def convert_errors(workflow)
+        workflow.xpath('//errors/error/text()').map(&:to_s)
+      end
+
+      def convert_created_at(workflow)
+        created_at = workflow.xpath('mediapackage/@start').last.to_s
+        created_at.present? ? Time.parse(created_at).utc : nil
+      end
+
+      def convert_updated_at(workflow)
+        updated_at = workflow.xpath('//operation[@state!="INSTANTIATED"]/completed/text()').last.to_s
+        updated_at.present? ? Time.strptime(updated_at, "%Q") : nil
+      end
+
+      def convert_output_created_at(track, workflow)
+        quality = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
+        created_at = workflow.xpath("//operation[@id=\"compose\"][configurations/configuration[@key=\"target-tags\" and contains(text(), \"#{quality}\")]]/started/text()").to_s
+        created_at.present? ? Time.at(created_at.to_i / 1000.0).utc : nil
+      end
+
+      def convert_output_updated_at(track, workflow)
+        quality = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
+        updated_at = workflow.xpath("//operation[@id=\"compose\"][configurations/configuration[@key=\"target-tags\" and contains(text(), \"#{quality}\")]]/completed/text()").to_s
+        updated_at.present? ? Time.at(updated_at.to_i / 1000.0).utc : nil
+      end
+
+      def convert_options(workflow)
+        options = {}
+        options[:preset] = workflow.xpath('template/text()').to_s
+        if workflow.xpath('//properties/property[@key="avalon.stream_base"]/text()').present?
+          options[:stream_base] = workflow.xpath('//properties/property[@key="avalon.stream_base"]/text()').to_s
+        end # this is avalon-felix specific
+        options
+      end
+
+      def convert_track_metadata(track)
+        return {} if track.nil?
+        metadata = {}
+        # metadata[:mime_type] = track.at("mimetype/text()").to_s if track.at('mimetype')
+        metadata[:checksum] = track.at("checksum/text()").to_s.strip if track.at('checksum')
+        metadata[:duration] = track.at("duration/text()").to_s.to_i if track.at('duration')
+        if track.at('audio')
+          metadata[:audio_codec] = track.at("audio/encoder/@type").to_s
+          metadata[:audio_channels] = track.at("audio/channels/text()").to_s
+          metadata[:audio_bitrate] = track.at("audio/bitrate/text()").to_s.to_f
         end
-
-        def build_encode(workflow)
-          return nil if workflow.nil?
-          input_url = convert_input(workflow)
-          input_url = get_workflow_title(workflow) if input_url.blank?
-          encode = ActiveEncode::Base.new(input_url, convert_options(workflow))
-          encode.id = convert_id(workflow)
-          encode.state = convert_state(workflow)
-          encode.current_operations = convert_current_operations(workflow)
-          encode.percent_complete = calculate_percent_complete(workflow)
-          encode.created_at = convert_created_at(workflow)
-          encode.updated_at = convert_updated_at(workflow) || encode.created_at
-          encode.output = convert_output(workflow, encode.options)
-          encode.errors = convert_errors(workflow)
-
-          encode.input.id = "presenter/source"
-          encode.input.state = encode.state
-          encode.input.created_at = encode.created_at
-          encode.input.updated_at = encode.updated_at
-          tech_md = convert_tech_metadata(workflow)
-          [:width, :height, :duration, :frame_rate, :checksum, :audio_codec, :video_codec,
-           :audio_bitrate, :video_bitrate].each do |field|
-            encode.input.send("#{field}=", tech_md[field])
-          end
-
-          encode
+        if track.at('video')
+          metadata[:video_codec] = track.at("video/encoder/@type").to_s
+          metadata[:video_bitrate] = track.at("video/bitrate/text()").to_s.to_f
+          metadata[:frame_rate] = track.at("video/framerate/text()").to_s.to_f
+          metadata[:width] = track.at("video/resolution/text()").to_s.split('x')[0].to_i
+          metadata[:height] = track.at("video/resolution/text()").to_s.split('x')[1].to_i
         end
+        metadata
+      end
 
-        def convert_id(workflow)
-          workflow.attribute('id').to_s
+      def get_media_package(workflow)
+        mp = workflow.xpath('//mediapackage')
+        first_node = mp.first
+        first_node['xmlns'] = 'http://mediapackage.opencastproject.org'
+        mp
+      end
+
+      def calculate_percent_complete(workflow)
+        totals = {
+          transcode: 70,
+          distribution: 20,
+          other: 10
+        }
+
+        completed_transcode_operations = workflow.xpath('//operation[@id="compose" and (@state="SUCCEEDED" or @state="SKIPPED")]').size
+        total_transcode_operations = workflow.xpath('//operation[@id="compose"]').size
+        total_transcode_operations = 1 if total_transcode_operations.zero?
+        completed_distribution_operations = workflow.xpath('//operation[starts-with(@id,"distribute") and (@state="SUCCEEDED" or @state="SKIPPED")]').size
+        total_distribution_operations = workflow.xpath('//operation[starts-with(@id,"distribute")]').size
+        total_distribution_operations = 1 if total_distribution_operations.zero?
+        completed_other_operations = workflow.xpath('//operation[@id!="compose" and not(starts-with(@id,"distribute")) and (@state="SUCCEEDED" or @state="SKIPPED")]').size
+        total_other_operations = workflow.xpath('//operation[@id!="compose" and not(starts-with(@id,"distribute"))]').size
+        total_other_operations = 1 if total_other_operations.zero?
+
+        ((totals[:transcode].to_f / total_transcode_operations) * completed_transcode_operations) +
+          ((totals[:distribution].to_f / total_distribution_operations) * completed_distribution_operations) +
+          ((totals[:other].to_f / total_other_operations) * completed_other_operations)
+      end
+
+      def create_multiple_files(input, workflow_id)
+        # Create empty media package xml document
+        mp = Rubyhorn.client.createMediaPackage
+
+        # Next line associates workflow title to avalon via masterfile pid
+        title = File.basename(input.values.first)
+        dc = Nokogiri::XML('<dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dcterms:title>' + title + '</dcterms:title></dublincore>')
+        mp = Rubyhorn.client.addDCCatalog('mediaPackage' => mp.to_xml, 'dublinCore' => dc.to_xml, 'flavor' => 'dublincore/episode')
+
+        # Add quality levels - repeated for each supplied file url
+        input.each_pair do |quality, url|
+          mp = Rubyhorn.client.addTrack('mediaPackage' => mp.to_xml, 'url' => url, 'flavor' => DEFAULT_ARGS['flavor'])
+          # Rewrite track to include quality tag
+          # Get the empty tags element under the newly added track
+          tags = mp.xpath('//xmlns:track/xmlns:tags[not(node())]', 'xmlns' => 'http://mediapackage.opencastproject.org').first
+          quality_tag = Nokogiri::XML::Node.new 'tag', mp
+          quality_tag.content = quality
+          tags.add_child quality_tag
         end
-
-        def get_workflow_state(workflow)
-          workflow.attribute('state').to_s
-        end
-
-        def convert_state(workflow)
-          case get_workflow_state(workflow)
-          when "INSTANTIATED", "RUNNING" # Should there be a queued state?
-            :running
-          when "STOPPED"
-            :cancelled
-          when "FAILED"
-            workflow.xpath('//operation[@state="FAILED"]').empty? ? :cancelled : :failed
-          when "SUCCEEDED", "SKIPPED" # Should there be a errored state?
-            :completed
-          end
-        end
-
-        def convert_input(workflow)
-          # Need to do anything else since this is a MH url? and this disappears when a workflow is cleaned up
-          workflow.xpath('mediapackage/media/track[@type="presenter/source"]/url/text()').to_s.strip
-        end
-
-        def get_workflow_title(workflow)
-          workflow.xpath('mediapackage/title/text()').to_s.strip
-        end
-
-        def convert_tech_metadata(workflow)
-          convert_track_metadata(workflow.xpath('//track[@type="presenter/source"]').first)
-        end
-
-        def convert_output(workflow, options)
-          outputs = []
-          workflow.xpath('//track[@type="presenter/delivery" and tags/tag[text()="streaming"]]').each do |track|
-            output = ActiveEncode::Output.new
-            output.label = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
-            output.url = track.at("url/text()").to_s
-            if output.url.start_with? "rtmp"
-              output.url = File.join(options[:stream_base], MatterhornRtmpUrl.parse(output.url).to_path) if options[:stream_base]
-            end
-            output.id = track.at("@id").to_s
-
-            tech_md = convert_track_metadata(track)
-            [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
-             :audio_bitrate, :video_bitrate, :file_size].each do |field|
-              output.send("#{field}=", tech_md[field])
-            end
-
-            output.state = :completed
-            output.created_at = convert_output_created_at(track, workflow)
-            output.updated_at = convert_output_updated_at(track, workflow)
-
-            outputs << output
-          end
-          outputs
-        end
-
-        def convert_current_operations(workflow)
-          current_op = workflow.xpath('//operation[@state!="INSTANTIATED"]/@description').last.to_s
-          current_op.present? ? [current_op] : []
-        end
-
-        def convert_errors(workflow)
-          workflow.xpath('//errors/error/text()').map(&:to_s)
-        end
-
-        def convert_created_at(workflow)
-          created_at = workflow.xpath('mediapackage/@start').last.to_s
-          created_at.present? ? Time.parse(created_at).utc : nil
-        end
-
-        def convert_updated_at(workflow)
-          updated_at = workflow.xpath('//operation[@state!="INSTANTIATED"]/completed/text()').last.to_s
-          updated_at.present? ? Time.strptime(updated_at, "%Q") : nil
-        end
-
-        def convert_output_created_at(track, workflow)
-          quality = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
-          created_at = workflow.xpath("//operation[@id=\"compose\"][configurations/configuration[@key=\"target-tags\" and contains(text(), \"#{quality}\")]]/started/text()").to_s
-          created_at.present? ? Time.at(created_at.to_i / 1000.0).utc : nil
-        end
-
-        def convert_output_updated_at(track, workflow)
-          quality = track.xpath('tags/tag[starts-with(text(),"quality")]/text()').to_s
-          updated_at = workflow.xpath("//operation[@id=\"compose\"][configurations/configuration[@key=\"target-tags\" and contains(text(), \"#{quality}\")]]/completed/text()").to_s
-          updated_at.present? ? Time.at(updated_at.to_i / 1000.0).utc : nil
-        end
-
-        def convert_options(workflow)
-          options = {}
-          options[:preset] = workflow.xpath('template/text()').to_s
-          options[:stream_base] = workflow.xpath('//properties/property[@key="avalon.stream_base"]/text()').to_s if workflow.xpath('//properties/property[@key="avalon.stream_base"]/text()').present? # this is avalon-felix specific
-          options
-        end
-
-        def convert_track_metadata(track)
-          return {} if track.nil?
-          metadata = {}
-          # metadata[:mime_type] = track.at("mimetype/text()").to_s if track.at('mimetype')
-          metadata[:checksum] = track.at("checksum/text()").to_s.strip if track.at('checksum')
-          metadata[:duration] = track.at("duration/text()").to_s.to_i if track.at('duration')
-          if track.at('audio')
-            metadata[:audio_codec] = track.at("audio/encoder/@type").to_s
-            metadata[:audio_channels] = track.at("audio/channels/text()").to_s
-            metadata[:audio_bitrate] = track.at("audio/bitrate/text()").to_s.to_f
-          end
-          if track.at('video')
-            metadata[:video_codec] = track.at("video/encoder/@type").to_s
-            metadata[:video_bitrate] = track.at("video/bitrate/text()").to_s.to_f
-            metadata[:frame_rate] = track.at("video/framerate/text()").to_s.to_f
-            metadata[:width] = track.at("video/resolution/text()").to_s.split('x')[0].to_i
-            metadata[:height] = track.at("video/resolution/text()").to_s.split('x')[1].to_i
-          end
-          metadata
-        end
-
-        def get_media_package(workflow)
-          mp = workflow.xpath('//mediapackage')
-          first_node = mp.first
-          first_node['xmlns'] = 'http://mediapackage.opencastproject.org'
-          mp
-        end
-
-        def calculate_percent_complete(workflow)
-          totals = {
-            transcode: 70,
-            distribution: 20,
-            other: 10
-          }
-
-          completed_transcode_operations = workflow.xpath('//operation[@id="compose" and (@state="SUCCEEDED" or @state="SKIPPED")]').size
-          total_transcode_operations = workflow.xpath('//operation[@id="compose"]').size
-          total_transcode_operations = 1 if total_transcode_operations.zero?
-          completed_distribution_operations = workflow.xpath('//operation[starts-with(@id,"distribute") and (@state="SUCCEEDED" or @state="SKIPPED")]').size
-          total_distribution_operations = workflow.xpath('//operation[starts-with(@id,"distribute")]').size
-          total_distribution_operations = 1 if total_distribution_operations.zero?
-          completed_other_operations = workflow.xpath('//operation[@id!="compose" and not(starts-with(@id,"distribute")) and (@state="SUCCEEDED" or @state="SKIPPED")]').size
-          total_other_operations = workflow.xpath('//operation[@id!="compose" and not(starts-with(@id,"distribute"))]').size
-          total_other_operations = 1 if total_other_operations.zero?
-
-          ((totals[:transcode].to_f / total_transcode_operations) * completed_transcode_operations) +
-            ((totals[:distribution].to_f / total_distribution_operations) * completed_distribution_operations) +
-            ((totals[:other].to_f / total_other_operations) * completed_other_operations)
-        end
-
-        def create_multiple_files(input, workflow_id)
-          # Create empty media package xml document
-          mp = Rubyhorn.client.createMediaPackage
-
-          # Next line associates workflow title to avalon via masterfile pid
-          title = File.basename(input.values.first)
-          dc = Nokogiri::XML('<dublincore xmlns="http://www.opencastproject.org/xsd/1.0/dublincore/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dcterms:title>' + title + '</dcterms:title></dublincore>')
-          mp = Rubyhorn.client.addDCCatalog('mediaPackage' => mp.to_xml, 'dublinCore' => dc.to_xml, 'flavor' => 'dublincore/episode')
-
-          # Add quality levels - repeated for each supplied file url
-          input.each_pair do |quality, url|
-            mp = Rubyhorn.client.addTrack('mediaPackage' => mp.to_xml, 'url' => url, 'flavor' => DEFAULT_ARGS['flavor'])
-            # Rewrite track to include quality tag
-            # Get the empty tags element under the newly added track
-            tags = mp.xpath('//xmlns:track/xmlns:tags[not(node())]', 'xmlns' => 'http://mediapackage.opencastproject.org').first
-            quality_tag = Nokogiri::XML::Node.new 'tag', mp
-            quality_tag.content = quality
-            tags.add_child quality_tag
-          end
-          # Finally ingest the media package
+        # Finally ingest the media package
+        begin
+                Rubyhorn.client.start("definitionId" => workflow_id, "mediapackage" => mp.to_xml)
+        rescue Rubyhorn::RestClient::Exceptions::HTTPBadRequest
+          # make this two calls...one to get the workflow definition xml and then the second to submit it along with the mediapackage to start...due to unsolved issue with some MH installs
           begin
-                  Rubyhorn.client.start("definitionId" => workflow_id, "mediapackage" => mp.to_xml)
-                rescue Rubyhorn::RestClient::Exceptions::HTTPBadRequest
-                  # make this two calls...one to get the workflow definition xml and then the second to submit it along with the mediapackage to start...due to unsolved issue with some MH installs
-                  begin
-                          workflow_definition_xml = Rubyhorn.client.definition_xml(workflow_id)
-                          Rubyhorn.client.start("definition" => workflow_definition_xml, "mediapackage" => mp.to_xml)
-                        rescue Rubyhorn::RestClient::Exceptions::HTTPNotFound
-                          raise StandardError, "Unable to start workflow"
-                        end
+                  workflow_definition_xml = Rubyhorn.client.definition_xml(workflow_id)
+                  Rubyhorn.client.start("definition" => workflow_definition_xml, "mediapackage" => mp.to_xml)
+          rescue Rubyhorn::RestClient::Exceptions::HTTPNotFound
+            raise StandardError, "Unable to start workflow"
                 end
-        end
+              end
+      end
     end
 
     class MatterhornRtmpUrl
@@ -268,7 +270,7 @@ module ActiveEncode
   /(?<stream_id>[^\/]+)      # stream_id   (b3d5663d-53f1-4f7d-b7be-b52fd5ca50a3)
   /(?<filename>.+?)          # filename    (MVI_0057)
   (?:\.(?<extension>.+))?$   # extension   (mp4)
-      }x
+      }x.freeze
 
       # @param [MatchData] match_data
       def initialize(match_data)

--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -73,7 +73,7 @@ module ActiveEncode
         new_encode.percent_complete = 1
         new_encode.errors = [e.full_message]
         write_errors new_encode
-        return new_encode
+        new_encode
       end
 
       # Return encode object from file system
@@ -110,7 +110,7 @@ module ActiveEncode
         encode.percent_complete = 1
         encode.errors = [e.full_message]
         write_errors encode
-        return encode
+        encode
       end
 
       # Cancel ongoing encode using pid file

--- a/lib/active_encode/engine_adapters/zencoder_adapter.rb
+++ b/lib/active_encode/engine_adapters/zencoder_adapter.rb
@@ -19,138 +19,138 @@ module ActiveEncode
 
       private
 
-        def get_job_details(job_id)
-          Zencoder::Job.details(job_id)
+      def get_job_details(job_id)
+        Zencoder::Job.details(job_id)
+      end
+
+      def get_job_progress(job_id)
+        Zencoder::Job.progress(job_id)
+      end
+
+      def build_encode(job_details)
+        return nil if job_details.nil?
+        encode = ActiveEncode::Base.new(convert_input(job_details), convert_options(job_details))
+        encode.id = job_details.body["job"]["id"].to_s
+        encode.state = convert_state(get_job_state(job_details))
+        job_progress = get_job_progress(encode.id)
+        encode.current_operations = convert_current_operations(job_progress)
+        encode.percent_complete = convert_percent_complete(job_progress, job_details)
+        encode.created_at = job_details.body["job"]["created_at"]
+        encode.updated_at = job_details.body["job"]["updated_at"]
+        encode.errors = []
+
+        encode.output = convert_output(job_details, job_progress)
+
+        encode.input.id = job_details.body["job"]["input_media_file"]["id"].to_s
+        encode.input.errors = convert_input_errors(job_details)
+        tech_md = convert_tech_metadata(job_details.body["job"]["input_media_file"])
+        [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
+         :audio_bitrate, :video_bitrate, :file_size].each do |field|
+          encode.input.send("#{field}=", tech_md[field])
         end
+        encode.input.state = convert_state(job_details.body["job"]["input_media_file"]["state"])
+        encode.input.created_at = job_details.body["job"]["input_media_file"]["created_at"]
+        encode.input.updated_at = job_details.body["job"]["input_media_file"]["updated_at"]
 
-        def get_job_progress(job_id)
-          Zencoder::Job.progress(job_id)
+        encode
+      end
+
+      def convert_state(state)
+        case state
+        when "assigning", "pending", "waiting", "processing" # Should there be a queued state?
+          :running
+        when "cancelled"
+          :cancelled
+        when "failed", "no_input"
+          :failed
+        when "finished"
+          :completed
         end
+      end
 
-        def build_encode(job_details)
-          return nil if job_details.nil?
-          encode = ActiveEncode::Base.new(convert_input(job_details), convert_options(job_details))
-          encode.id = job_details.body["job"]["id"].to_s
-          encode.state = convert_state(get_job_state(job_details))
-          job_progress = get_job_progress(encode.id)
-          encode.current_operations = convert_current_operations(job_progress)
-          encode.percent_complete = convert_percent_complete(job_progress, job_details)
-          encode.created_at = job_details.body["job"]["created_at"]
-          encode.updated_at = job_details.body["job"]["updated_at"]
-          encode.errors = []
+      def get_job_state(job_details)
+        job_details.body["job"]["state"]
+      end
 
-          encode.output = convert_output(job_details, job_progress)
+      def convert_current_operations(job_progress)
+        current_ops = []
+        job_progress.body["outputs"].each { |output| current_ops << output["current_event"] unless output["current_event"].nil? }
+        current_ops
+      end
 
-          encode.input.id = job_details.body["job"]["input_media_file"]["id"].to_s
-          encode.input.errors = convert_input_errors(job_details)
-          tech_md = convert_tech_metadata(job_details.body["job"]["input_media_file"])
+      def convert_percent_complete(job_progress, job_details)
+        percent = job_progress.body["progress"]
+        percent ||= 100 if convert_state(get_job_state(job_details)) == :completed
+        percent ||= 0
+        percent
+      end
+
+      def convert_input(job_details)
+        job_details.body["job"]["input_media_file"]["url"]
+      end
+
+      def convert_options(_job_details)
+        {}
+      end
+
+      def convert_output(job_details, job_progress)
+        job_details.body["job"]["output_media_files"].collect do |o|
+          output = ActiveEncode::Output.new
+          output.id = o["id"].to_s
+          output.label = o["label"]
+          output.url = o["url"]
+          output.errors = Array(o["error_message"])
+
+          tech_md = convert_tech_metadata(o)
           [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
            :audio_bitrate, :video_bitrate, :file_size].each do |field|
-            encode.input.send("#{field}=", tech_md[field])
+            output.send("#{field}=", tech_md[field])
           end
-          encode.input.state = convert_state(job_details.body["job"]["input_media_file"]["state"])
-          encode.input.created_at = job_details.body["job"]["input_media_file"]["created_at"]
-          encode.input.updated_at = job_details.body["job"]["input_media_file"]["updated_at"]
-
-          encode
+          output_progress = job_progress.body["outputs"].find { |out_prog| out_prog["id"] = output.id }
+          output.state = convert_state(output_progress["state"])
+          output.created_at = o["created_at"]
+          output.updated_at = o["updated_at"]
+          output
         end
+      end
 
-        def convert_state(state)
-          case state
-          when "assigning", "pending", "waiting", "processing" # Should there be a queued state?
-            :running
-          when "cancelled"
-            :cancelled
-          when "failed", "no_input"
-            :failed
-          when "finished"
-            :completed
-          end
-        end
+      def convert_input_errors(job_details)
+        Array(job_details.body["job"]["input_media_file"]["error_message"])
+      end
 
-        def get_job_state(job_details)
-          job_details.body["job"]["state"]
-        end
+      def convert_tech_metadata(media_file)
+        return {} if media_file.nil?
 
-        def convert_current_operations(job_progress)
-          current_ops = []
-          job_progress.body["outputs"].each { |output| current_ops << output["current_event"] unless output["current_event"].nil? }
-          current_ops
-        end
-
-        def convert_percent_complete(job_progress, job_details)
-          percent = job_progress.body["progress"]
-          percent ||= 100 if convert_state(get_job_state(job_details)) == :completed
-          percent ||= 0
-          percent
-        end
-
-        def convert_input(job_details)
-          job_details.body["job"]["input_media_file"]["url"]
-        end
-
-        def convert_options(_job_details)
-          {}
-        end
-
-        def convert_output(job_details, job_progress)
-          job_details.body["job"]["output_media_files"].collect do |o|
-            output = ActiveEncode::Output.new
-            output.id = o["id"].to_s
-            output.label = o["label"]
-            output.url = o["url"]
-            output.errors = Array(o["error_message"])
-
-            tech_md = convert_tech_metadata(o)
-            [:width, :height, :frame_rate, :duration, :checksum, :audio_codec, :video_codec,
-             :audio_bitrate, :video_bitrate, :file_size].each do |field|
-              output.send("#{field}=", tech_md[field])
-            end
-            output_progress = job_progress.body["outputs"].find { |out_prog| out_prog["id"] = output.id }
-            output.state = convert_state(output_progress["state"])
-            output.created_at = o["created_at"]
-            output.updated_at = o["updated_at"]
-            output
+        metadata = {}
+        media_file.each_pair do |key, value|
+          next if value.blank?
+          case key
+          when "md5_checksum"
+            metadata[:checksum] = value
+          when "format"
+            metadata[:mime_type] = value
+          when "duration_in_ms"
+            metadata[:duration] = value
+          when "audio_codec"
+            metadata[:audio_codec] = value
+          when "channels"
+            metadata[:audio_channels] = value
+          when "audio_bitrate_in_kbps"
+            metadata[:audio_bitrate] = value
+          when "video_codec"
+            metadata[:video_codec] = value
+          when "frame_rate"
+            metadata[:frame_rate] = value
+          when "video_bitrate_in_kbps"
+            metadata[:video_bitrate] = value
+          when "width"
+            metadata[:width] = value
+          when "height"
+            metadata[:height] = value
           end
         end
-
-        def convert_input_errors(job_details)
-          Array(job_details.body["job"]["input_media_file"]["error_message"])
-        end
-
-        def convert_tech_metadata(media_file)
-          return {} if media_file.nil?
-
-          metadata = {}
-          media_file.each_pair do |key, value|
-            next if value.blank?
-            case key
-            when "md5_checksum"
-              metadata[:checksum] = value
-            when "format"
-              metadata[:mime_type] = value
-            when "duration_in_ms"
-              metadata[:duration] = value
-            when "audio_codec"
-              metadata[:audio_codec] = value
-            when "channels"
-              metadata[:audio_channels] = value
-            when "audio_bitrate_in_kbps"
-              metadata[:audio_bitrate] = value
-            when "video_codec"
-              metadata[:video_codec] = value
-            when "frame_rate"
-              metadata[:frame_rate] = value
-            when "video_bitrate_in_kbps"
-              metadata[:video_bitrate] = value
-            when "width"
-              metadata[:width] = value
-            when "height"
-              metadata[:height] = value
-            end
-          end
-          metadata
-        end
+        metadata
+      end
     end
   end
 end

--- a/lib/active_encode/persistence.rb
+++ b/lib/active_encode/persistence.rb
@@ -27,25 +27,25 @@ module ActiveEncode
 
     private
 
-      def persist(encode_attributes)
-        model = ActiveEncode::EncodeRecord.find_or_initialize_by(global_id: encode_attributes[:global_id])
-        model.update(encode_attributes) # Don't fail if persisting doesn't succeed?
-      end
+    def persist(encode_attributes)
+      model = ActiveEncode::EncodeRecord.find_or_initialize_by(global_id: encode_attributes[:global_id])
+      model.update(encode_attributes) # Don't fail if persisting doesn't succeed?
+    end
 
-      def persistence_model_attributes(encode, create_options = nil)
-        attributes = {
-          global_id: encode.to_global_id.to_s,
-          state: encode.state,
-          adapter: encode.class.engine_adapter.class.name,
-          title: encode.input.url.to_s,
-          # Need to ensure that these values come through or else validations will fail
-          created_at: encode.created_at,
-          updated_at: encode.updated_at,
-          raw_object: encode.to_json,
-          progress: encode.percent_complete
-        }
-        attributes[:create_options] = create_options.to_json if create_options.present?
-        attributes
-      end
+    def persistence_model_attributes(encode, create_options = nil)
+      attributes = {
+        global_id: encode.to_global_id.to_s,
+        state: encode.state,
+        adapter: encode.class.engine_adapter.class.name,
+        title: encode.input.url.to_s,
+        # Need to ensure that these values come through or else validations will fail
+        created_at: encode.created_at,
+        updated_at: encode.updated_at,
+        raw_object: encode.to_json,
+        progress: encode.percent_complete
+      }
+      attributes[:create_options] = create_options.to_json if create_options.present?
+      attributes
+    end
   end
 end

--- a/spec/integration/matterhorn_adapter_spec.rb
+++ b/spec/integration/matterhorn_adapter_spec.rb
@@ -102,11 +102,10 @@ describe ActiveEncode::EngineAdapters::MatterhornAdapter do
   end
 
   describe "reload" do
+    subject { running_job.reload }
     before do
       expect(Rubyhorn.client).to receive(:instance_xml).twice.with('running-id').and_return(Rubyhorn::Workflow.from_xml(File.open('spec/fixtures/matterhorn/running_response.xml')))
     end
-
-    subject { running_job.reload }
 
     it { expect(subject.output).to be_empty }
     it { expect(subject.options).to include(preset: 'full') }

--- a/spec/integration/zencoder_adapter_spec.rb
+++ b/spec/integration/zencoder_adapter_spec.rb
@@ -20,12 +20,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
   let(:file) { "file://#{File.absolute_path('spec/fixtures/Bars_512kb.mp4')}" }
 
   describe "#create" do
+    subject { ActiveEncode::Base.create(file) }
     before do
       allow(Zencoder::Job).to receive(:details).and_return(details_response)
       allow(Zencoder::Job).to receive(:progress).and_return(progress_response)
     end
 
-    subject { ActiveEncode::Base.create(file) }
     let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_create.json'))) }
     let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_create.json'))) }
     let(:create_output) { [{ id: "511404522", url: "https://zencoder-temp-storage-us-east-1.s3.amazonaws.com/o/20150610/c09b61e4d130ddf923f0653418a80b9c/399ae101c3f99b4f318635e78a4e587a.mp4?AWSAccessKeyId=AKIAI456JQ76GBU7FECA&Signature=GY/9LMkQAiDOrMQwS5BkmOE200s%3D&Expires=1434033527", label: nil }] }
@@ -302,13 +302,13 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
   end
 
   describe "#cancel!" do
+    subject { encode.cancel! }
     before do
       allow(Zencoder::Job).to receive(:cancel).and_return(cancel_response)
       allow(Zencoder::Job).to receive(:details).and_return(details_response)
       allow(Zencoder::Job).to receive(:progress).and_return(progress_response)
     end
 
-    subject { encode.cancel! }
     let(:cancel_response) { Zencoder::Response.new(code: 200) } # TODO: check that this is the correct response code for a successful cancel
     let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_cancelled.json'))) }
     let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_cancelled.json'))) }
@@ -320,12 +320,12 @@ describe ActiveEncode::EngineAdapters::ZencoderAdapter do
   end
 
   describe "reload" do
+    subject { ActiveEncode::Base.find('166019107').reload }
     before do
       allow(Zencoder::Job).to receive(:details).and_return(details_response)
       allow(Zencoder::Job).to receive(:progress).and_return(progress_response)
     end
 
-    subject { ActiveEncode::Base.find('166019107').reload }
     let(:details_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_details_running.json'))) }
     let(:progress_response) { Zencoder::Response.new(body: JSON.parse(File.read('spec/fixtures/zencoder/job_progress_running.json'))) }
     # let(:reload_output) { [{ id: "510582971", url: "https://zencoder-temp-storage-us-east-1.s3.amazonaws.com/o/20150609/48a6907086c012f68b9ca43461280515/1726d7ec3e24f2171bd07b2abb807b6c.mp4?AWSAccessKeyId=AKIAI456JQ76GBU7FECA&Signature=vSvlxU94wlQLEbpG3Zs8ibp4MoY%3D&Expires=1433953106", label: nil }] }

--- a/spec/units/core_spec.rb
+++ b/spec/units/core_spec.rb
@@ -128,6 +128,7 @@ describe ActiveEncode::Core do
   end
 
   describe '#new' do
+    subject { encode.options }
     before do
       class DefaultOptionsEncode < ActiveEncode::Base
         def self.default_options(_input_url)
@@ -139,7 +140,6 @@ describe ActiveEncode::Core do
       Object.send(:remove_const, :DefaultOptionsEncode)
     end
 
-    subject { encode.options }
     let(:encode_class) { DefaultOptionsEncode }
     let(:default_options) { { preset: 'video' } }
     let(:options) { { output: [{ label: 'high', ffmpeg_opt: "640x480" }] } }

--- a/spec/units/file_locator_spec.rb
+++ b/spec/units/file_locator_spec.rb
@@ -41,7 +41,7 @@ describe FileLocator, type: :service do
   describe "Local file" do
     let(:path) { "/path/to/file.mp4" }
     let(:source) { "file://#{path}" }
-    let(:locator) { FileLocator.new(source) }
+    let(:locator) { described_class.new(source) }
 
     it "returns the correct uri" do
       expect(locator.uri).to eq Addressable::URI.parse(source)
@@ -76,7 +76,7 @@ describe FileLocator, type: :service do
     let(:bucket) { "mybucket" }
     let(:key) { "mykey.mp4" }
     let(:source) { "s3://#{bucket}/#{key}" }
-    let(:locator) { FileLocator.new(source) }
+    let(:locator) { described_class.new(source) }
 
     it "returns the correct uri" do
       expect(locator.uri).to eq Addressable::URI.parse(source)
@@ -102,7 +102,7 @@ describe FileLocator, type: :service do
   describe "Other file" do
     let(:path) { "/path/to/file.mp4" }
     let(:source) { "bogus://#{path}" }
-    let(:locator) { FileLocator.new(source) }
+    let(:locator) { described_class.new(source) }
 
     it "returns the correct uri" do
       expect(locator.uri).to eq Addressable::URI.parse(source)

--- a/spec/units/status_spec.rb
+++ b/spec/units/status_spec.rb
@@ -2,6 +2,7 @@
 require 'spec_helper'
 
 describe ActiveEncode::Status do
+  subject { encode_class.new(nil) }
   before do
     class CustomEncode < ActiveEncode::Base
     end
@@ -10,7 +11,6 @@ describe ActiveEncode::Status do
     Object.send(:remove_const, :CustomEncode)
   end
 
-  subject { encode_class.new(nil) }
   let(:encode_class) { ActiveEncode::Base }
 
   describe 'attributes' do


### PR DESCRIPTION
The latest bixby with more recent rubocop resulted in lots of violations. I had rubocop fix the all with --auto-correct. It's a lot of files... if tests still pass I guess we're good? Not sure. 

I was able to remove the rubocop exclusions @mbklein added in #90, they no longer apply. 

I had to add an exclusion having to do with the Rakefile; new rubocop didn't like the weird old setup involving `task 'environment' do`, but I didn't want to get into totally understanding what that did or how to safely change it, so I just excluded the test. 

