### PR TITLE
Move addressable to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in hydra-transcoder.gemspec
 gemspec
 
-gem 'addressable'
 gem 'aws-sdk-elastictranscoder'
 gem 'aws-sdk-s3'
 gem 'byebug'

--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails"
+  spec.add_dependency "addressable", "~> 2.8"
 
   spec.add_development_dependency "aws-sdk-cloudwatchevents"
   spec.add_development_dependency "aws-sdk-cloudwatchlogs"


### PR DESCRIPTION
Addressable gem is used by actual runtime code!  It needs to be in the gemspec. Otherwise if an app using active_encode doesn't already have addressable as it's own dependency for other reasons -- when the active_encode logic that uses addressable is reached, it'll error!

I am not sure if other things listed in the Gemfile may also be in this state -- I think some other things listed in Gemfile may not actually be used at all anymore, like "shingoncoder"? I
could find no reference to that one in codebase. But didn't touch it here.

There is also the issue of all the adapter-specific dependencies that aren't listed as dependencies... But we're just dealing with addressable here


