### PR TITLE
MediaConvert: Memoize lookup of AWS endpoints in #mediaconvert

### DIFF
--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -290,8 +290,10 @@ module ActiveEncode
       end
 
       def mediaconvert
-        endpoint = Aws::MediaConvert::Client.new.describe_endpoints.endpoints.first.url
-        @mediaconvert ||= Aws::MediaConvert::Client.new(endpoint: endpoint)
+        @mediaconvert ||= begin
+          endpoint = Aws::MediaConvert::Client.new.describe_endpoints.endpoints.first.url
+          Aws::MediaConvert::Client.new(endpoint: endpoint)
+        end
       end
 
       def s3_uri(url, options = {})


### PR DESCRIPTION
The #mediaconvert method attempted to memoize (cache) it's creation of a MediaConvert client, by using `@mediaconvert ||`, so it would be created the first time then re-used.

However, the lookup of AWS endpoints happened on every method call anyway. This is actually the expensive part, as it's an AWS HTTP API call.  Additionally, it's rate-limited by AWS, so I was getting AWS TooManyRequests exceptions on calling #mediaconvert too many times, because each time it was doing an endpoint lookup and then throwing ou the results because it already had a client memoized!

Make sure the endpoints lookup is inside the block that gets memoized/cached.

@mbklein
