### PR TITLE
MediaConvert adapter has direct_output_lookup config, to avoid using CloudWatch

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,11 +18,16 @@ Metrics/ClassLength:
   Exclude:
     - 'lib/active_encode/engine_adapters/*'
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'lib/active_encode/engine_adapters/*'
+
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'lib/active_encode/engine_adapters/elastic_transcoder_adapter.rb'
     - 'lib/active_encode/engine_adapters/ffmpeg_adapter.rb'
     - 'lib/active_encode/engine_adapters/zencoder_adapter.rb'
+    - 'lib/active_encode/engine_adapters/media_convert_adapter.rb'
 
 Layout/LineLength:
   Exclude:

--- a/guides/media_convert_adapter.md
+++ b/guides/media_convert_adapter.md
@@ -25,17 +25,17 @@ or `video_codec` will be nil.
 
 ## CloudWatch and EventBridge setup, optionally with setup!
 
-[AWS Elemental MediaConvert](https://aws.amazon.com/mediaconvert/) doesn't provide detailed
-output information in the job description that can be pulled directly from the service.
-Instead, it provides that information in a job status notification when the job
-status changes to `COMPLETE`. The only way to capture that notification is through an [Amazon
-Eventbridge](https://aws.amazon.com/eventbridge/) rule that forwards the status change
+[AWS Elemental MediaConvert](https://aws.amazon.com/mediaconvert/) makes it difficult to acesss
+detailed output information in the job description that can be pulled directly from the service. One way to work around this is capture the MediaConvert job status notification
+when the job status changes to `COMPLETE`, via an
+[Amazon Eventbridge](https://aws.amazon.com/eventbridge/) rule that forwards the status change
 notification to another service for capture and/or handling -- for instance a CloudWatch Logs]
 (https://aws.amazon.com/cloudwatch/) log group.
 
 `ActiveEncode::EngineAdapters::MediaConvert` is written to get detailed output information from just such a setup, a CloudWatch log group that has been set up to receive MediaConvert job status `COMPLETE` notifications via an EventBridge rule.
 
 We proide a method to create this CloudWatch and EventBridge infrastructure for you, the `#setup!` method.
+
 
 ```ruby
 ActiveEncode::Base.engine_adapter = :media_convert
@@ -50,6 +50,14 @@ The `setup!` task will create an EventBridge rule name and CloudWatch log group 
 * Log group name: `/aws/events/active-encode/mediaconvert/Default`
 
 The names chosen will respect the `log_group` and `queue` config though, if set.
+
+
+**Alternately**, we have an experimental flag to get and derive what output information we can
+directly from the job without requiring a CloudWatch log -- this is expected to be complete
+only for  HLS output at present. It seems to work well for HLS output. To opt-in, and not require CloudWatch logs, try:
+
+    ActiveEncode::Base.engine_adapter.direct_output_lookup = true
+
 
 ## Configuration
 

--- a/lib/active_encode/engine_adapters/media_convert_output.rb
+++ b/lib/active_encode/engine_adapters/media_convert_output.rb
@@ -30,6 +30,25 @@ module ActiveEncode
           "XAVC" => :xavc_settings
         }.freeze
 
+        # @param output_url [String] url, expected to be `s3://`
+        # @param output_settings [Aws::MediaConvert::Types::Output]
+        # @param output_detail_settings [Aws::MediaConvert::Types::OutputDetail]
+        def tech_metadata_from_settings(output_url:, output_settings:, output_detail_settings:)
+          {
+            width: output_detail_settings.video_details.width_in_px,
+            height: output_detail_settings.video_details.height_in_px,
+            frame_rate: extract_video_frame_rate(output_settings),
+            duration: output_detail_settings.duration_in_ms,
+            audio_codec: extract_audio_codec(output_settings),
+            video_codec: extract_video_codec(output_settings),
+            audio_bitrate: extract_audio_bitrate(output_settings),
+            video_bitrate: extract_video_bitrate(output_settings),
+            url: output_url,
+            label: (output_url ? File.basename(output_url) : output_settings.name_modifier),
+            suffix: output_settings.name_modifier
+          }
+        end
+
         def tech_metadata_from_logged(settings, logged_output)
           url = logged_output.dig('outputFilePaths', 0)
           {
@@ -45,6 +64,49 @@ module ActiveEncode
             label: File.basename(url),
             suffix: settings.name_modifier
           }
+        end
+
+        # constructs an `s3:` output URL  from the MediaConvert job params, the same
+        # way MediaConvert will.
+        #
+        # @example
+        #   construct_output_filename(
+        #     destination: "s3://bucket/base_name",
+        #     original_filename: "foo.mp3",
+        #     name_modifier: "-1080",
+        #     suffix: "m3u8")
+        #   # =>  "s3://bucket/base_name-1080.m3u8"
+        #
+        # @example
+        #   construct_output_filename(
+        #     destination: "s3://bucket/directory_end_in_slash/",
+        #     original_filename: "original-filename.mp3",
+        #     name_modifier: "-1080",
+        #     suffix: "m3u8")
+        #   # =>  "s3://bucket/directory_end_in_slash/original_filename-1080.m3u8"
+        #
+        # @example
+        #   construct_output_filename(
+        #     destination: "s3://bucket/directory_end_in_slash/",
+        #     original_filename: "original-filename.mp3",
+        #     name_modifier: nil,
+        #     suffix: "m3u8")
+        #   # =>  "s3://bucket/directory_end_in_slash/original_filename.m3u8"
+        def construct_output_url(destination:, file_input_url:, name_modifier:, file_suffix:)
+          output = destination
+
+          # MediaConvert operates such that if you give a destination ending in '/',
+          # it'll use the original file name as part of output url.
+          if output.end_with?('/')
+            # ".*" on the end will strip extension off
+            output += File.basename(file_input_url, '.*')
+          end
+
+          output += name_modifier if name_modifier
+
+          output += "." + file_suffix
+
+          output
         end
 
         def extract_audio_codec(settings)

--- a/lib/active_encode/engine_adapters/media_convert_output.rb
+++ b/lib/active_encode/engine_adapters/media_convert_output.rb
@@ -30,13 +30,13 @@ module ActiveEncode
           "XAVC" => :xavc_settings
         }.freeze
 
-        def tech_metadata(settings, output)
-          url = output.dig('outputFilePaths', 0)
+        def tech_metadata_from_logged(settings, logged_output)
+          url = logged_output.dig('outputFilePaths', 0)
           {
-            width: output.dig('videoDetails', 'widthInPx'),
-            height: output.dig('videoDetails', 'heightInPx'),
+            width: logged_output.dig('videoDetails', 'widthInPx'),
+            height: logged_output.dig('videoDetails', 'heightInPx'),
             frame_rate: extract_video_frame_rate(settings),
-            duration: output['durationInMs'],
+            duration: logged_output['durationInMs'],
             audio_codec: extract_audio_codec(settings),
             video_codec: extract_video_codec(settings),
             audio_bitrate: extract_audio_bitrate(settings),

--- a/spec/integration/media_convert_adapter_spec.rb
+++ b/spec/integration/media_convert_adapter_spec.rb
@@ -176,4 +176,26 @@ describe ActiveEncode::EngineAdapters::MediaConvertAdapter do
       end
     end
   end
+
+  describe "direct_output_lookup" do
+    before do
+      ActiveEncode::Base.engine_adapter.direct_output_lookup = true
+    end
+
+    it "contains all expected outputs" do
+      completed_output.each do |expected_output|
+        found_output = completed_job.output.find { |output| output.id == expected_output[:id] }
+        expected_output.each_pair do |key, value|
+          expect(found_output.send(key)).to eq(value)
+        end
+      end
+    end
+
+    it "does not make cloudwatch queries" do
+      expect(cloudwatch_logs).not_to receive(:start_query)
+      expect(cloudwatch_logs).not_to receive(:get_query_results)
+
+      completed_job
+    end
+  end
 end


### PR DESCRIPTION
MediaConvert adapter has direct_output_lookup config

To calculate output directly from the MediaConvert Job object, without requiring the CloudWatch logs.

(Also includes a commit that renamed some methods/variables for clarity, and added inline comments.)

All the info we were returning is there EXCEPT the actual output URLs. Sufficient info is there to calculate/predict the output URLs though -- I have done that for HLS. I believe it should be do-able for other formats too, but I am no
t familiar with them to figure out what they should be, so for NOW the URL calculation is only there for HLS. (If it's important, I could try to familiarize myself with the others and how the adapter currently handles them and try to match them without CloudWatch too? Not sure what other outputs are in any actual use at present, if any?)

This logic makes some assumptions, like that hteres only one input file and only one output group -- but I _think_ such assumptions were already being made, and the adapter at current is incapable of violating them. It does potentiall
y introduce some additional fragility though.
