### PR TITLE
MediaConvert support direct 'destination' output arg

### DIFF
--- a/guides/media_convert_adapter.md
+++ b/guides/media_convert_adapter.md
@@ -72,7 +72,7 @@ ActiveEncode::Base.engine_adapter.output_bucket = 'my-bucket-name'
 ```
 
 
-## Input options, and the masterfile_bucket
+## Input and output options, and the masterfile_bucket
 
 The adapter can take a local file as argument (via `file://` URL or any other standard way for ActiveEncode), _or_ an `s3://` URL.
 
@@ -115,7 +115,25 @@ ActiveEncode::Base.create(
 # it will not be copied to the masterfile_bucket first.
 ```
 
-Only in this case of `use_original_url` and an `s3://` input source, the `masterfile_bucket` argumetn can be ommitted, since it will be used.
+Only in this case of `use_original_url` and an `s3://` input source, the `masterfile_bucket` argument can be ommitted, since it will be used.
+
+You can also use `desitnation` instead of `output_prefix`, to supply a complete `s3://` url,
+ignoring `output_bucket` config. With `use_original_url` you can now supply inputs and
+outputs as simple s3 urls.
+
+```ruby
+ActiveEncode::Base.create(
+  "s3://some-other-bucket/path/to/file.mp4",
+  {
+    use_original_url: true,
+    destination: "s3://my-output-bucket/path/to/output/base_name_of_outputs",
+    outputs: [
+      { preset: "my-hls-preset-high", modifier: "_high" },
+      { preset: "my-hls-preset-medium", modifier: "_medium" },
+    ]
+  }
+)
+```
 
 ## AWS Auth Credentials
 

--- a/guides/media_convert_adapter.md
+++ b/guides/media_convert_adapter.md
@@ -117,7 +117,7 @@ ActiveEncode::Base.create(
 
 Only in this case of `use_original_url` and an `s3://` input source, the `masterfile_bucket` argument can be ommitted, since it will be used.
 
-You can also use `desitnation` instead of `output_prefix`, to supply a complete `s3://` url,
+You can also use `destination` instead of `output_prefix`, to supply a complete `s3://` url,
 ignoring `output_bucket` config. With `use_original_url` you can now supply inputs and
 outputs as simple s3 urls.
 

--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -156,7 +156,16 @@ module ActiveEncode
 
       # Required options:
       #
-      # * `output_prefix`: The S3 key prefix to use as the base for all outputs.
+      # * `output_prefix`: The S3 key prefix to use as the base for all outputs. Will be
+      #                    combined with configured `output_bucket` to be passed to MediaConvert
+      #                    `destination`. Alternately see `destination` arg; one or the other
+      #                    is required.
+      #
+      # * `destination`: The full s3:// URL to be passed to MediaConvert `destination` as output
+      #                  location an filename base.  `output_bucket` config is ignored if you
+      #                  pass `destination`. Alternately see `output_prefix` arg; one or the
+      #                  other is required.
+      #
       #
       # * `outputs`: An array of `{preset, modifier}` options defining how to transcode and
       #              name the outputs. The "modifier" option will be passed as `name_modifier`
@@ -452,7 +461,9 @@ module ActiveEncode
         output_type = options[:output_type] || :hls
         raise ArgumentError, "Unknown output type: #{output_type.inspect}" unless OUTPUT_GROUP_TEMPLATES.keys.include?(output_type)
         output_group_settings_key = "#{output_type}_group_settings".to_sym
-        output_group_settings = OUTPUT_GROUP_TEMPLATES[output_type].merge(destination: "s3://#{output_bucket}/#{options[:output_prefix]}")
+
+        destination = options[:destination] || "s3://#{output_bucket}/#{options[:output_prefix]}"
+        output_group_settings = OUTPUT_GROUP_TEMPLATES[output_type].merge(destination: destination)
 
         outputs = options[:outputs].map do |output|
           {

--- a/spec/integration/media_convert_adapter_spec.rb
+++ b/spec/integration/media_convert_adapter_spec.rb
@@ -136,13 +136,29 @@ describe ActiveEncode::EngineAdapters::MediaConvertAdapter do
         outputs: [],
         use_original_url: true
       )
-      create_job_operation = operations.find {|o| o[:operation_name] == :create_job}
+      create_job_operation = operations.find { |o| o[:operation_name] == :create_job }
       expect(create_job_operation).to be_present
 
       destination = create_job_operation.dig(:params, :settings, :output_groups, 0,
         :output_group_settings, :hls_group_settings, :destination)
 
       expect(destination).to eq("s3://output-bucket/active-encode-test/output")
+    end
+
+    it "can use destination arg" do
+      ActiveEncode::Base.create(
+        "s3://input-bucket/test_files/source_file.mp4",
+        destination: "s3://alternate-output-bucket/my-path/output",
+        outputs: [],
+        use_original_url: true
+      )
+      create_job_operation = operations.find { |o| o[:operation_name] == :create_job }
+      expect(create_job_operation).to be_present
+
+      destination = create_job_operation.dig(:params, :settings, :output_groups, 0,
+        :output_group_settings, :hls_group_settings, :destination)
+
+      expect(destination).to eq("s3://alternate-output-bucket/my-path/output")
     end
   end
 


### PR DESCRIPTION
Previously, you specified the output location  by configuring output_bucket globally, and then setting output_prefix on the create call.

These are combined by code to pass to MediaConvert as an s3://  url in the  destination parameter.

This PR provides an alternate option, just pass a `destination` arg with an s3:// url to create, not using output_bucket at all. This is an arg of the same format that MediaConvert itself uses, passed directly to MediaConvert. It is more convenient in some situations to simply pass the destinations on a per-call basis, the same way you would to MediaConvert. 
