### PR TITLE
Remove sprockets pin

### DIFF
--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -37,7 +37,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency "rspec-rails"
-
-  # Pin sprockets to < 4 so it works with ruby 2.5+
-  spec.add_dependency 'sprockets', '< 4'
 end


### PR DESCRIPTION
I think this was added before because early releases of sprockets 4 didn't play nicely with ruby 2.7, but I believe those issues were resolved in future sprockets releases.