### PR TITLE
MediaConvert adapter create has output_group_destination_settings config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ AllCops:
 
 Rails/RakeEnvironment:
   Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false

--- a/lib/active_encode/engine_adapters/media_convert_adapter.rb
+++ b/lib/active_encode/engine_adapters/media_convert_adapter.rb
@@ -201,6 +201,12 @@ module ActiveEncode
       #                  create_job API.
       #
       #
+      # * `output_group_destination_settings`: A hash of additional `destination_settings` to be
+      #                  sent to MediaConvert with the output_group.  Can include `s3_settings` key
+      #                  with  `access_control` and `encryption` settings. See examples at:
+      #                  https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/MediaConvert/Client.html#create_job-instance_method
+      #
+      #
       # Example:
       # {
       #   output_prefix: "path/to/output/files",
@@ -573,6 +579,10 @@ module ActiveEncode
 
         destination = options[:destination] || "s3://#{output_bucket}/#{options[:output_prefix]}"
         output_group_settings = OUTPUT_GROUP_TEMPLATES[output_type].merge(destination: destination)
+
+        if options[:output_group_destination_settings]
+          output_group_settings[:destination_settings] = options[:output_group_destination_settings]
+        end
 
         outputs = options[:outputs].map do |output|
           {


### PR DESCRIPTION
You can supply a hash that will be passed to MediaConvert destination_settings in the relevant output group configuration.

I needed this for my app for a use case where I need to tell MediaConvert to use canned PUBLIC_READ acl when creating files. I could have created a feature just for like `canned_acl`, but it was simpler to implement and seemed convenient to let the caller pass in any `destination_settings`; the only other one that exists is basically S3 encryption, but, hey, maybe somebody wants that.

In addition to writing a mocked test, I have tested this with my live app, it works.
