### PR TITLE
Improve error handling for ffmpeg adapter

### DIFF
--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -111,7 +111,7 @@ module ActiveEncode
         elsif cancelled? encode.id
           encode.state = :cancelled
         elsif encode.percent_complete < 100
-          encode.errors << "Encoding has completed but the output duration is shorter than the input"
+          encode.errors.prepend("Encoding has completed but the output duration is shorter than the input")
           encode.state = :failed
         end
 
@@ -170,7 +170,7 @@ module ActiveEncode
         err_path = working_path("error.log", id)
         error = File.read(err_path) if File.file? err_path
         if error.present?
-          [error]
+          ["Error encountered during encoding. Check ffmpeg log for more details.", error]
         else
           []
         end
@@ -227,7 +227,7 @@ module ActiveEncode
           "#{k}: #{v}\r\n"
         end.join
         header_opt = "-headers '#{header_opt}'" if header_opt.present?
-        "#{FFMPEG_PATH} #{header_opt} -y -loglevel error -progress #{working_path('progress', id)} -i \"#{input_url}\" #{output_opt}"
+        "#{FFMPEG_PATH} #{header_opt} -y -loglevel level+fatal -progress #{working_path('progress', id)} -i \"#{input_url}\" #{output_opt}"
       end
 
       def sanitize_base(input_url)


### PR DESCRIPTION
- Bump ffmpeg loglevel to fatal due to very verbose error logging for some files
- Add level flag to ffmepg logging for clearer error messages
- Add a human-readable, explanatory note to the errors on the encode object before the dump of the stderr output
- Prepend fatal truncation error so it appears first in encode object's errors array

These changes are refinements based upon issues encountered while running in production.  We've seen error.log files of ~39MB generated.  These overflow the database column for `raw_object` in `ActiveEncode::EncodeRecord` and cause poor UX when Avalon indexes and displays the first error in the encode object's `errors` array.