### PR TITLE
Allow ffmpeg to add additional pieces to derivative filenames

### DIFF
--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -204,7 +204,7 @@ module ActiveEncode
           output = ActiveEncode::Output.new
           output.url = "file://#{file_path}"
           sanitized_filename = ActiveEncode.sanitize_base encode.input.url
-          output.label = file_path[/#{Regexp.quote(sanitized_filename)}\-(.*?)#{Regexp.quote(File.extname(file_path))}$/, 1]
+          output.label = file_path[/#{Regexp.quote(sanitized_filename)}.*\-(.*?)#{Regexp.quote(File.extname(file_path))}$/, 1]
           output.id = "#{encode.input.id}-#{output.label}"
           output.created_at = encode.created_at
           output.updated_at = File.mtime file_path


### PR DESCRIPTION
When processing s3 files ffmpeg adds "_alt_media" after the original filename which breaks the label determination.  Allow any character after the original sanitized input filename before the dash which separates the quality label and file extension.