### PR TITLE
Test with latest ruby/rails versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 2.0.2
+        default: 2.4.5
       ffmpeg_version:
         type: string
         default: 4.1.4
@@ -64,26 +64,30 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: "ruby3-2_rails7-0"
+          ruby_version: "3.2.0"
+          rails_version: "7.0.4.2"
+      - bundle_and_test:
+          name: "ruby3-1_rails7-0"
+          ruby_version: "3.1.3"
+          rails_version: "7.0.4.2"
+      - bundle_and_test:
           name: "ruby3-0_rails7-0"
-          ruby_version: "3.0.3"
-          rails_version: "7.0.1"
+          ruby_version: "3.0.5"
+          rails_version: "7.0.4.2"
       - bundle_and_test:
           name: "ruby3-0_rails6-1"
-          ruby_version: "3.0.3"
-          rails_version: "6.1.4.4"
+          ruby_version: "3.0.5"
+          rails_version: "6.1.7.2"
       - bundle_and_test:
           name: "ruby3-0_rails6-0"
-          ruby_version: "3.0.3"
-          rails_version: "6.0.4.4"
+          ruby_version: "3.0.5"
+          rails_version: "6.0.6.1"
       - bundle_and_test:
           name: "ruby2-7_rails6-0"
-          ruby_version: "2.7.5"
-          rails_version: "6.0.4.4"
+          ruby_version: "2.7.7"
+          rails_version: "6.0.6.1"
       - bundle_and_test:
           name: "ruby2-7_rails5-2"
-          ruby_version: "2.7.5"
-          rails_version: "5.2.6"
-      - bundle_and_test:
-          name: "ruby2-6_rails5-2"
-          ruby_version: "2.6.9"
-          rails_version: "5.2.6"
+          ruby_version: "2.7.7"
+          rails_version: "5.2.8.1"


### PR DESCRIPTION
Also drop testing of EOL 2.6 due to issue generating new testing app and update version of bundler for ruby 3.2 support.
