### PR TITLE
Keep spec/ out of built gem, to keep fixtures out, and reduce gem package by 176 megabytes

### DIFF
--- a/active_encode.gemspec
+++ b/active_encode.gemspec
@@ -15,9 +15,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/samvera-labs/active_encode"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  # Keep spec/ files out of built gem, because fixture files are LARGE and
+  # really blow up built gem size by three orders of magnitude.
+
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^spec/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  #spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   spec.metadata      = { "rubygems_mfa_required" => "true" }
 


### PR DESCRIPTION
Keeping spec/ out of the built gem package reduces size of built gem package from 176M to 44K (yes that's megabytes to kilobytes). This is due to large mp4 and m4a "fixture" files in spec/fixtures. 

You can see size of built gem package by running `bundle exec rake build` and looking at `./pkg/active_encode-*.gem`

Closes #126

## Advantages

Built gem package has to be included with any app deploy. My entire (not small) app deploy size without active_encode (including all gem dependencies etc), is around 220M.  So an additional 176M is a pretty substantial 80% increase in size, in this case, nearly doubling it.

Increased bytes means more space on disk for the deployed app, and also means slower deployment as all those bytes need to be copied down.

(It also means slower 'bundle installs' even in dev, test, and CI, to copy down those bytes, if not already cached.). 

These costs can be exascerbated in some environments, such as PaaS such as heroku (which also puts a maximum size limit on deployments, which current active_encode pushes me much closer to), or possibly docker as well?

## Disadvantages


This PR would make it so you can no longer run tests from the rubygems distribution package alone. You need to actually check out the whole repo to run tests.

There are theoretical reasons one might want to run tests from rubygems package, and I've heard of for instance linux distro packagers who want to include a rubygem as part of a linux distro wanting to do this as an automate dprocess.  But I'm not aware of anyone in our actual community or ecosystem wanting/needing to do it with active-encode.  It's not actually a thing done practically very often, it's an edge case.

If it comes up in the future, we'd have to tackle it a different way, see Further Action below.

## Further Action

Removing 176M of fixtures from the rubygems distro package helps a lot of use cases, but the repo itself is still going to be 176M.

This would still hit people if they try to use the gem directly from github in their Gemfile (say, to get a pre-release version). And also of course any devs checking out the repo.

Do we really need 176M of fixtures?  It looks like that's a few 25M+ video files. Is it possible to create much smaller video files that still have the characteristics needed for running tests? I have a 1.4M mp4 video for testing purposes at https://github.com/sciencehistory/scihist_digicoll/tree/master/spec/test_support/video , that I got from a public domain source.

It might make sense to try to replace fixture data with similar smaller videos? Not sure how much smaller than 1.4MB is possible to get a legal mp4 or webm file that would have characteristics needed. Several 1.4M files would be better, but still result in a gem package larger than usual (almost all gem packages in my experience are less than 1M large in total).

So I think we should probably try to do this -- but still keep excluding spec/fixture from gem package unless there is a use case that really requires it.

I think most fixture files were added in recent commits by @masaball -- hooray for more test coverage, really appreciated!  Just had this unintended side effect, that we can fix if we can find smaller suitable fixture videos.
