### PR TITLE
Fix pass through adapter when using minio (s3)

### DIFF
--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -20,6 +20,7 @@ module ActiveEncode
       def create(input_url, options = {})
         # Decode file uris for ffmpeg (mediainfo works either way)
         input_url = Addressable::URI.unencode(input_url) if input_url.starts_with? "file:///"
+        input_url = FileLocator.new(input_url).location if input_url.starts_with? "s3://"
         input_url = ActiveEncode.sanitize_input(input_url)
 
         new_encode = ActiveEncode::Base.new(input_url, options)

--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -79,7 +79,11 @@ module ActiveEncode
         options[:outputs].each do |opt|
           url = opt[:url]
           output_path = working_path("outputs/#{ActiveEncode.sanitize_base opt[:url]}#{File.extname opt[:url]}", new_encode.id)
-          FileUtils.cp FileLocator.new(url).location, output_path
+          if url.start_with? "s3://"
+            FileLocator::S3File.new(url).object.download_file(output_path)
+          else
+            FileUtils.cp FileLocator.new(url).location, output_path
+          end
           filename_label_hash[output_path] = opt[:label]
         end
 

--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -17,11 +17,8 @@ module ActiveEncode
       MEDIAINFO_PATH = ENV["MEDIAINFO_PATH"] || "mediainfo"
       FFMPEG_PATH = ENV["FFMPEG_PATH"] || "ffmpeg"
 
-      def create(input_url, options = {})
-        # Decode file uris for ffmpeg (mediainfo works either way)
-        input_url = Addressable::URI.unencode(input_url) if input_url.starts_with? "file:///"
-        input_url = FileLocator.new(input_url).location if input_url.starts_with? "s3://"
-        input_url = ActiveEncode.sanitize_input(input_url)
+      def create(original_input_url, options = {})
+        input_url = sanitize_input_url(original_input_url)
 
         new_encode = ActiveEncode::Base.new(input_url, options)
         new_encode.id = SecureRandom.uuid
@@ -77,13 +74,7 @@ module ActiveEncode
 
         # Copy derivatives to work directory
         options[:outputs].each do |opt|
-          url = opt[:url]
-          output_path = working_path("outputs/#{ActiveEncode.sanitize_base opt[:url]}#{File.extname opt[:url]}", new_encode.id)
-          if url.start_with? "s3://"
-            FileLocator::S3File.new(url).object.download_file(output_path, mode: 'single_request')
-          else
-            FileUtils.cp FileLocator.new(url).location, output_path
-          end
+          output_path = copy_derivative_to_working_path(opt[:url], new_encode.id)
           filename_label_hash[output_path] = opt[:label]
         end
 
@@ -275,6 +266,31 @@ module ActiveEncode
 
         write_errors new_encode
         new_encode
+      end
+
+      def sanitize_input_url(url)
+        input_url = if url.starts_with?("file://")
+                      # Decode file uris for ffmpeg (mediainfo works either way)
+                      Addressable::URI.unencode(url)
+                    elsif url.starts_with?("s3://")
+                      # Change s3 uris into presigned http urls
+                      FileLocator.new(url).location
+                    else
+                      url
+                    end
+        ActiveEncode.sanitize_input(input_url)
+      end
+
+      def copy_derivative_to_working_path(url, id)
+        output_path = working_path("outputs/#{ActiveEncode.sanitize_base url}#{File.extname url}", id)
+        if url.start_with? "s3://"
+          # Use aws-sdk-s3 download_file method
+          # Single request mode needed for compatibility with minio
+          FileLocator::S3File.new(url).object.download_file(output_path, mode: 'single_request')
+        else
+          FileUtils.cp FileLocator.new(url).location, output_path
+        end
+        output_path
       end
     end
   end

--- a/lib/active_encode/engine_adapters/pass_through_adapter.rb
+++ b/lib/active_encode/engine_adapters/pass_through_adapter.rb
@@ -80,7 +80,7 @@ module ActiveEncode
           url = opt[:url]
           output_path = working_path("outputs/#{ActiveEncode.sanitize_base opt[:url]}#{File.extname opt[:url]}", new_encode.id)
           if url.start_with? "s3://"
-            FileLocator::S3File.new(url).object.download_file(output_path)
+            FileLocator::S3File.new(url).object.download_file(output_path, mode: 'single_request')
           else
             FileUtils.cp FileLocator.new(url).location, output_path
           end


### PR DESCRIPTION
A couple of changes were needed to make the pass through adapter usable with minio inside avalon:
- Convert s3 url to a presigned http url for use in mediainfo
- Use the `download_file` method supplied by `aws-sdk-s3` for transferring derivative to working directory