### PR TITLE
Convert HTTP strings to URI before processing

### DIFF
--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -28,6 +28,8 @@ module ActiveEncode
 
           s3_object = FileLocator::S3File.new(input_url).object
           input_url = URI.parse(s3_object.presigned_url(:get))
+        when /^https?\:\/\//
+          input_url = URI.parse(input_url)
         end
 
         new_encode = ActiveEncode::Base.new(input_url, options)


### PR DESCRIPTION
`sanitized_filename = ActiveEncode.sanitize_base input_url` is used when creating the file path for output files. If `input_url` contains a long query string such as is seen with Sharepoint download urls, the path cannot be created and the encode will fail. This may be due to file path length restrictions or possibly disallowed sequences of characters?

The `sanitize_base` method has handling for HTTP URIs that strips the query string, so we can convert strings starting with 'http' or 'https' to the URI class and rely on the handling already present in the sanitizer.