### PR TITLE
Fix output label generation when input url has query string

### DIFF
--- a/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
+++ b/lib/active_encode/engine_adapters/ffmpeg_adapter.rb
@@ -234,7 +234,7 @@ module ActiveEncode
         Dir["#{File.absolute_path(working_path('outputs', id))}/*"].each do |file_path|
           output = ActiveEncode::Output.new
           output.url = "file://#{file_path}"
-          sanitized_filename = ActiveEncode.sanitize_base encode.input.url
+          sanitized_filename = encode.input.url.match?(/^https?\:\/\//) ? ActiveEncode.sanitize_base(URI.parse(encode.input.url)) : ActiveEncode.sanitize_base(encode.input.url)
           output.label = file_path[/#{Regexp.quote(sanitized_filename)}.*\-(.*?)#{Regexp.quote(File.extname(file_path))}$/, 1]
           output.id = "#{encode.input.id}-#{output.label}"
           output.created_at = encode.created_at


### PR DESCRIPTION
The output label and id generation uses the input url from the technical metadata. Since this url is a string from the file, we must convert it to the URI class for Sharepoint urls to be properly sanitized and processed.