### PR TITLE
Use Addressable::URI.site when sanitizing S3 URIs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ else
     end
 
     case ENV['RAILS_VERSION']
+    when /^[56]/, /^7.0/
+      gem 'concurrent-ruby', '1.3.4'
     when /^6.0/
       gem 'sass-rails', '>= 6'
       gem 'webpacker', '~> 4.0'

--- a/lib/active_encode/filename_sanitizer.rb
+++ b/lib/active_encode/filename_sanitizer.rb
@@ -24,7 +24,7 @@ module ActiveEncode
       when /^file\:\/\/\//
         input_url.to_s.gsub(/file:\/\//, '')
       when /^s3\:\/\//
-        input_url.to_s.gsub(/#{Addressable::URI.parse(input_url).normalized_site}/, '')
+        input_url.to_s.gsub(/#{Addressable::URI.parse(input_url).site}/, '')
       when /^https?:\/\//
         input_url
       end

--- a/spec/units/filename_sanitizer_spec.rb
+++ b/spec/units/filename_sanitizer_spec.rb
@@ -8,13 +8,19 @@ describe ActiveEncode::FilenameSanitizer do
       uri = "file:///path/to/file"
       expect(ActiveEncode.sanitize_uri(uri)).to eq "/path/to/file"
     end
-    it 'relativizes s3 uris' do
-      uri = "s3://mybucket/guitar.mp4"
-      expect(ActiveEncode.sanitize_uri(uri)).to eq "/guitar.mp4"
-    end
     it 'does nothing for http(s) uris' do
       uri = "https://www.googleapis.com/drive/v3/files/1WkWJ12WecI9hX-PmEbuKDGLPK_mN3kYP?alt=media"
       expect(ActiveEncode.sanitize_uri(uri)).to eq uri
+    end
+    context 's3' do
+      it 'relativizes s3 uris' do
+        uri = "s3://mybucket/guitar.mp4"
+        expect(ActiveEncode.sanitize_uri(uri)).to eq "/guitar.mp4"
+      end
+      it 'handles capitalized buckets' do
+        uri = "s3://MYBucket/guitar.mp4"
+        expect(ActiveEncode.sanitize_uri(uri)).to eq "/guitar.mp4"
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #135

S3 URIs can have bucket names that are capitalized. `Addressable::URI.normalized_site` converts the site to lower case which would cause the substitution in `ActiveEncode.sanitize_uri`'s S3 case to fail from an unmatched Regex. Switching to `Addressable::URI.site` preserves capitalization and should fix the bug.